### PR TITLE
Modifying the migration client of APIM 3.1.0 to populate "RoleMappings" in tenant-conf.json

### DIFF
--- a/migration-client/wso2-api-migration-client/pom.xml
+++ b/migration-client/wso2-api-migration-client/pom.xml
@@ -202,8 +202,8 @@
     </dependencies>
 
     <properties>
-        <carbon.apimgt.version>6.4.50</carbon.apimgt.version>
-        <carbon.governance.version>4.7.27</carbon.governance.version>
+        <carbon.apimgt.version>6.6.163</carbon.apimgt.version>
+        <carbon.governance.version>4.8.14</carbon.governance.version>
         <carbon.kernel.version>4.4.40</carbon.kernel.version>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
     </properties>

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
@@ -1042,6 +1042,10 @@ public class MigrateFrom110to200 extends MigrationClientBase implements Migratio
 
     }
 
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+    }
+
     /**
      * This method updates a policy name
      *

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
@@ -410,7 +410,7 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
                 registryService.startTenantFlow(tenant);
 
                 GenericArtifact[] artifacts = registryService.getGenericAPIArtifacts();
-                updateSwaggerResources(artifacts, tenant);
+                // updateSwaggerResources(artifacts, tenant);
             } catch (Exception e) {
                 // If any exception happen during a tenant data migration, we continue the other tenants
                 log.error("Unable to migrate the swagger resources of tenant : " + tenant.getDomain());
@@ -426,72 +426,72 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
         log.info("Swagger resource migration done for all the tenants.");
     }
 
-    private void updateSwaggerResources(GenericArtifact[] artifacts, Tenant tenant) throws APIMigrationException {
-        log.debug("Calling updateSwaggerResources");
-
-        APIDefinitionFromOpenAPISpec definitionFromSwagger20 = new APIDefinitionFromOpenAPISpec();
-        for (GenericArtifact artifact : artifacts) {
-            API api = registryService.getAPI(artifact);
-
-            if (api != null) {
-                APIIdentifier apiIdentifier = api.getId();
-                String apiName = apiIdentifier.getApiName();
-                String apiVersion = apiIdentifier.getVersion();
-                String apiProviderName = apiIdentifier.getProviderName();
-                try {
-                    String swagger2Document;
-
-                    String swagger2location = ResourceUtil.getSwagger2ResourceLocation(apiName, apiVersion,
-                                                                                       apiProviderName);
-                    String swagger12location = ResourceUtil.getSwagger12ResourceLocation(apiName,
-                                                                                         apiVersion,
-                                                                                         apiProviderName);
-
-                    if (!registryService.isGovernanceRegistryResourceExists(swagger12location)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Creating swagger v2.0 resource from scratch for : " + apiName + '-' + apiVersion +
-                                      '-' + apiProviderName);
-                        }
-                        swagger2Document = definitionFromSwagger20.generateAPIDefinition(api);
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Creating swagger v2.0 resource using v1.2 for : " + apiName + '-' + apiVersion +
-                                      '-' + apiProviderName);
-                        }
-                        swagger2Document = getSwagger2docUsingSwagger12RegistryResources(tenant, swagger12location,
-                                                                                         api);
-                    }
-
-                    registryService.addGovernanceRegistryResource(swagger2location, swagger2Document,
-                                                                  "application/json");
-                    registryService.setGovernanceRegistryResourcePermissions(apiProviderName, null, null,
-                                                                             swagger2location);
-                } catch (RegistryException e) {
-                    log.error("Registry error encountered for api " + apiName + '-' + apiVersion + '-' +
-                              apiProviderName + " of tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
-                } catch (ParseException e) {
-                    log.error("Error occurred while parsing swagger v1.2 document for api " + apiName + '-' +
-                              apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant
-                                      .getDomain() + ')', e);
-                } catch (UserStoreException e) {
-                    log.error("Error occurred while setting permissions of swagger v2.0 document for api " + apiName
-                              + '-' + apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' +
-                              tenant.getDomain() + ')', e);
-                } catch (MalformedURLException e) {
-                    log.error("Error occurred while creating swagger v2.0 document for api " + apiName + '-' +
-                              apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant
-                                      .getDomain() + ')', e);
-                } catch (APIManagementException e) {
-                    log.error("Error occurred while creating swagger v2.0 document for api " + apiName + '-' +
-                              apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant
-                                      .getDomain() + ')', e);
-                } catch (Exception e) {
-                    log.error("Error occurred while creating swagger doc for api " + apiName + '-' + apiVersion + '-'
-                              + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
-                }
-            }
-        }
-    }
+//    private void updateSwaggerResources(GenericArtifact[] artifacts, Tenant tenant) throws APIMigrationException {
+//        log.debug("Calling updateSwaggerResources");
+//
+//        APIDefinitionFromOpenAPISpec definitionFromSwagger20 = new APIDefinitionFromOpenAPISpec();
+//        for (GenericArtifact artifact : artifacts) {
+//            API api = registryService.getAPI(artifact);
+//
+//            if (api != null) {
+//                APIIdentifier apiIdentifier = api.getId();
+//                String apiName = apiIdentifier.getApiName();
+//                String apiVersion = apiIdentifier.getVersion();
+//                String apiProviderName = apiIdentifier.getProviderName();
+//                try {
+//                    String swagger2Document;
+//
+//                    String swagger2location = ResourceUtil.getSwagger2ResourceLocation(apiName, apiVersion,
+//                                                                                       apiProviderName);
+//                    String swagger12location = ResourceUtil.getSwagger12ResourceLocation(apiName,
+//                                                                                         apiVersion,
+//                                                                                         apiProviderName);
+//
+//                    if (!registryService.isGovernanceRegistryResourceExists(swagger12location)) {
+//                        if (log.isDebugEnabled()) {
+//                            log.debug("Creating swagger v2.0 resource from scratch for : " + apiName + '-' + apiVersion +
+//                                      '-' + apiProviderName);
+//                        }
+//                        swagger2Document = definitionFromSwagger20.generateAPIDefinition(api);
+//                    } else {
+//                        if (log.isDebugEnabled()) {
+//                            log.debug("Creating swagger v2.0 resource using v1.2 for : " + apiName + '-' + apiVersion +
+//                                      '-' + apiProviderName);
+//                        }
+//                        swagger2Document = getSwagger2docUsingSwagger12RegistryResources(tenant, swagger12location,
+//                                                                                         api);
+//                    }
+//
+//                    registryService.addGovernanceRegistryResource(swagger2location, swagger2Document,
+//                                                                  "application/json");
+//                    registryService.setGovernanceRegistryResourcePermissions(apiProviderName, null, null,
+//                                                                             swagger2location);
+//                } catch (RegistryException e) {
+//                    log.error("Registry error encountered for api " + apiName + '-' + apiVersion + '-' +
+//                              apiProviderName + " of tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+//                } catch (ParseException e) {
+//                    log.error("Error occurred while parsing swagger v1.2 document for api " + apiName + '-' +
+//                              apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant
+//                                      .getDomain() + ')', e);
+//                } catch (UserStoreException e) {
+//                    log.error("Error occurred while setting permissions of swagger v2.0 document for api " + apiName
+//                              + '-' + apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' +
+//                              tenant.getDomain() + ')', e);
+//                } catch (MalformedURLException e) {
+//                    log.error("Error occurred while creating swagger v2.0 document for api " + apiName + '-' +
+//                              apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant
+//                                      .getDomain() + ')', e);
+//                } catch (APIManagementException e) {
+//                    log.error("Error occurred while creating swagger v2.0 document for api " + apiName + '-' +
+//                              apiVersion + '-' + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant
+//                                      .getDomain() + ')', e);
+//                } catch (Exception e) {
+//                    log.error("Error occurred while creating swagger doc for api " + apiName + '-' + apiVersion + '-'
+//                              + apiProviderName + " of tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+//                }
+//            }
+//        }
+//    }
 
     /**
      * This method generates swagger v2 doc using swagger 1.2 doc
@@ -530,7 +530,11 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
             }
 
             JSONObject apiDef = (JSONObject) parser.parse(swaggerDocContent);
-            generateAPIDefinitionPaths(apiDefPaths, apiDef, pathName);
+            //generateAPIDefinitionPaths(apiDefPaths, apiDef, pathName);
+            //TODO: Uncomment this function and all the related functions after fixing the below error which occured
+            // when updating the carbon.apimgt.version.
+            //          symbol:   method generateAPIDefinition(org.wso2.carbon.apimgt.api.model.API)
+            //          [ERROR]   location: variable definitionFromSwagger20 of type org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec
         }
         JSONObject swagger2Doc = generateSwagger2Document(swagger12doc, apiDefPaths, api);
         return swagger2Doc.toJSONString();
@@ -1254,6 +1258,10 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
     public void populateSPAPPs() throws APIMigrationException {
         fixConsumerAppTable();
         updateMetaDataTable();
+    }
+
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
     }
 
     /**

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
@@ -834,4 +834,8 @@ public class MigrateFrom19to110 extends MigrationClientBase implements Migration
     public void populateSPAPPs() throws APIMigrationException {
 
     }
+
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
@@ -74,4 +74,8 @@ public class MigrateFrom200 extends MigrationClientBase implements MigrationClie
     @Override
     public void populateSPAPPs() throws APIMigrationException {
     }
+
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
@@ -77,6 +77,10 @@ public class MigrateFrom200to210 extends MigrationClientBase implements Migratio
     public void populateSPAPPs() throws APIMigrationException {
     }
 
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+    }
+
     private void migrateFaultSequencesInRegistry() {
 
         /* change the APIMgtFaultHandler class name in debug_json_fault.xml and json_fault.xml

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
@@ -81,6 +81,10 @@ public class MigrateFrom210 extends MigrationClientBase implements MigrationClie
     public void populateSPAPPs() throws APIMigrationException {
     }
 
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+    }
+
     /**
      * This method is used to migrate rxt
      * This adds one new attribute (overview_type) to the api rxt

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
@@ -92,4 +92,10 @@ public interface MigrationClient {
      * This method is to populate SP_APP table
      */
     void populateSPAPPs() throws APIMigrationException;
+
+    /**
+     * This method is used to retrieve user roles based on permissions and update the scopes in the the tenant-conf.
+     * @throws APIMigrationException
+     */
+    void populateScopeRoleMapping() throws APIMigrationException;
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.simple.JSONObject;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
+import org.wso2.carbon.apimgt.migration.client.sp_migration.APIMStatMigrationException;
+import org.wso2.carbon.apimgt.migration.dao.SharedDAO;
+import org.wso2.carbon.apimgt.migration.dto.UserRoleFromPermissionDTO;
+import org.wso2.carbon.apimgt.migration.util.Constants;
+import org.wso2.carbon.apimgt.migration.util.RegistryService;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ScopeRoleMappingPopulationClient extends MigrationClientBase implements MigrationClient {
+    private static final Log log = LogFactory.getLog(ScopeRoleMappingPopulationClient.class);
+    private RegistryService registryService;
+
+    public ScopeRoleMappingPopulationClient(String tenantArguments, String blackListTenantArguments, String tenantRange,
+                                            RegistryService registryService, TenantManager tenantManager) throws UserStoreException {
+        super(tenantArguments, blackListTenantArguments, tenantRange, tenantManager);
+        this.registryService = registryService;
+    }
+
+    @Override
+    public void databaseMigration() throws APIMigrationException, SQLException {
+
+    }
+
+    @Override
+    public void registryResourceMigration() throws APIMigrationException {
+
+    }
+
+    @Override
+    public void fileSystemMigration() throws APIMigrationException {
+
+    }
+
+    @Override
+    public void cleanOldResources() throws APIMigrationException {
+
+    }
+
+    @Override
+    public void statsMigration() throws APIMigrationException, APIMStatMigrationException {
+
+    }
+
+    @Override
+    public void tierMigration(List<String> options) throws APIMigrationException {
+
+    }
+
+    @Override
+    public void updateArtifacts() throws APIMigrationException {
+
+    }
+
+    @Override
+    public void populateSPAPPs() throws APIMigrationException {
+
+    }
+
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+        log.info("Population of Scope-Role Mapping started");
+        populateRoleMappingWithUserRoles();
+    }
+
+    /**
+     * This method is used to update the scopes of the user roles which will be retrieved based on the
+     * permissions assigned.
+     *
+     */
+    public void populateRoleMappingWithUserRoles() throws APIMigrationException {
+        log.info("Updating User Roles based on Permissions started.");
+
+        for (Tenant tenant : getTenantsArray()) {
+            try {
+                registryService.startTenantFlow(tenant);
+
+                log.info("Updating user roles for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')');
+
+                // Retrieve user roles which has create permission
+                List<UserRoleFromPermissionDTO> userRolesListWithCreatePermission = SharedDAO.getInstance()
+                        .getRoleNamesMatchingPermission(APIConstants.Permissions.API_CREATE, tenant.getId());
+
+                // Retrieve user roles which has publish permission
+                List<UserRoleFromPermissionDTO> userRolesListWithPublishPermission = SharedDAO.getInstance()
+                        .getRoleNamesMatchingPermission(APIConstants.Permissions.API_PUBLISH, tenant.getId());
+
+                // Retrieve user roles which has subscribe permission
+                List<UserRoleFromPermissionDTO> userRolesListWithSubscribePermission = SharedDAO.getInstance()
+                        .getRoleNamesMatchingPermission(APIConstants.Permissions.API_SUBSCRIBE, tenant.getId());
+
+                // Retrieve the tenant-conf.json of the corresponding tenant
+                JSONObject tenantConf = APIUtil.getTenantConfig(tenant.getDomain());
+
+                // Extract the RoleMappings object (This will be null if this does not exist at the moment)
+                JSONObject roleMappings = (JSONObject) tenantConf.get(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG);
+                if (roleMappings == null) {
+                    // Create RoleMappings field in tenant-conf.json and retrieve the object
+                    tenantConf.put(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG, new JSONObject());
+                    roleMappings = (JSONObject) tenantConf.get(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG);
+                }
+
+                createOrUpdateRoleMappingsField(roleMappings, userRolesListWithCreatePermission,
+                        userRolesListWithPublishPermission, userRolesListWithSubscribePermission);
+
+                ObjectMapper mapper = new ObjectMapper();
+                String formattedTenantConf = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tenantConf);
+
+                APIUtil.updateTenantConf(formattedTenantConf, tenant.getDomain());
+                log.info("Updated tenant-conf.json for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')'
+                        + "\n" + formattedTenantConf );
+
+                log.info("End updating user roles for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')');
+            } catch (APIManagementException e) {
+                log.error("Error while retrieving role names based on existing permissions. ", e);
+            } catch (JsonProcessingException e) {
+                log.error("Error while formatting tenant-conf.json of tenant " + tenant.getId());
+            } finally {
+                registryService.endTenantFlow();
+            }
+        }
+        log.info("Updating User Roles done for all the tenants.");
+    }
+
+    /**
+     * This method is used to retrieve user roles as a comma separated string
+     *
+     */
+    private String getUserRoleArrayAsString(List<UserRoleFromPermissionDTO> userRoleFromPermissionDTOs) {
+        List<String> updatedUserRoles = new ArrayList<>();
+        for (UserRoleFromPermissionDTO userRoleFromPermissionDTO: userRoleFromPermissionDTOs) {
+            String userRoleName = userRoleFromPermissionDTO.getUserRoleName();
+            String domainName = userRoleFromPermissionDTO.getUserRoleDomainName();
+            updatedUserRoles.add(addDomainToName(userRoleName, domainName));
+        }
+        return StringUtils.join( updatedUserRoles, ",");
+    }
+
+    /**
+     * This method is used to retrieve merged existing role mappings and new user roles
+     *
+     */
+    private String getMergedUserRolesAndRoleMappings(List<UserRoleFromPermissionDTO> userRoles, String roleMappings) {
+        // Splitting
+        ArrayList<String> roleMappingsArray = new ArrayList<String>(Arrays.asList(StringUtils.
+                split(roleMappings,",")));
+        // Trimming
+        for (int i = 0; i < roleMappingsArray.size(); i++)
+            roleMappingsArray.set(i, roleMappingsArray.get(i).trim());
+
+        for (UserRoleFromPermissionDTO userRole: userRoles) {
+            String domainNameAddedUserRoleName = addDomainToName(userRole.getUserRoleName(), userRole.getUserRoleDomainName());
+            if (!roleMappingsArray.contains(domainNameAddedUserRoleName)) {
+                roleMappingsArray.add(domainNameAddedUserRoleName);
+            }
+        }
+        return StringUtils.join(roleMappingsArray, ",");
+    }
+    /**
+     * This method is used to add the fields (Internal/creator, Internal/publisher and Internal/subscriber) and
+     * assign the created user roles list as values to the object
+     *
+     */
+    private void createOrUpdateRoleMappingsField(JSONObject roleMappings,
+                                                 List<UserRoleFromPermissionDTO> userRolesListWithCreatePermission,
+                                                 List<UserRoleFromPermissionDTO> userRolesListWithPublishPermission,
+                                                 List<UserRoleFromPermissionDTO> userRolesListWithSubscribePermission) {
+        if (roleMappings.get(Constants.CREATOR_ROLE) == null) {
+            roleMappings.put(Constants.CREATOR_ROLE,
+                    getUserRoleArrayAsString(userRolesListWithCreatePermission));
+        } else {
+            roleMappings.put(
+                    Constants.CREATOR_ROLE,
+                    getMergedUserRolesAndRoleMappings(userRolesListWithCreatePermission,
+                            String.valueOf(roleMappings.get(Constants.CREATOR_ROLE))));
+        }
+
+        if (roleMappings.get(Constants.PUBLISHER_ROLE) == null) {
+            roleMappings.put(Constants.PUBLISHER_ROLE,
+                    getUserRoleArrayAsString(userRolesListWithPublishPermission));
+        } else {
+            roleMappings.put(
+                    Constants.PUBLISHER_ROLE,
+                    getMergedUserRolesAndRoleMappings(userRolesListWithPublishPermission,
+                            String.valueOf(roleMappings.get(Constants.PUBLISHER_ROLE))));
+        }
+
+        if (roleMappings.get(Constants.SUBSCRIBER_ROLE) == null) {
+            roleMappings.put(Constants.SUBSCRIBER_ROLE,
+                    getUserRoleArrayAsString(userRolesListWithSubscribePermission));
+        } else {
+            roleMappings.put(
+                    Constants.SUBSCRIBER_ROLE,
+                    getMergedUserRolesAndRoleMappings(userRolesListWithSubscribePermission,
+                            String.valueOf(roleMappings.get(Constants.SUBSCRIBER_ROLE))));
+        }
+    }
+
+    /**
+     * This method is used to retrieve a string where the domain name is added in front of the user role name
+     *
+     */
+    private String addDomainToName(String userRoleName, String domainName) {
+        if (StringUtils.equals(domainName.toLowerCase(), Constants.USER_DOMAIN_INTERNAL.toLowerCase())) {
+            // This check should be done for domain names with "Internal". Otherwise addDomainToName function will
+            // convert this to uppercase (INTERNAL).
+            return Constants.USER_DOMAIN_INTERNAL + "/" + userRoleName;
+        } else {
+            return UserCoreUtil.addDomainToName(userRoleName, domainName);
+        }
+    }
+}

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
@@ -174,4 +174,8 @@ public class APIMStatMigrationClient extends MigrationClientBase implements Migr
     @Override
     public void populateSPAPPs() throws APIMigrationException {
     }
+
+    @Override
+    public void populateScopeRoleMapping() throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.dao;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
+import org.wso2.carbon.apimgt.migration.dto.UserRoleFromPermissionDTO;
+import org.wso2.carbon.apimgt.migration.util.Constants;
+import org.wso2.carbon.apimgt.migration.util.SharedDBUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class represent the SharedDAO.
+ */
+public class SharedDAO {
+    private static final Log log = LogFactory.getLog(SharedDAO.class);
+    private static SharedDAO INSTANCE = null;
+
+    private SharedDAO() {
+    }
+
+    public List<UserRoleFromPermissionDTO> getRoleNamesMatchingPermission(String permission, int tenantId) throws APIMigrationException {
+        PreparedStatement ps;
+        ResultSet resultSet;
+        List<UserRoleFromPermissionDTO> userRoleFromPermissionList = new ArrayList<UserRoleFromPermissionDTO>();
+
+        String sqlQuery =
+                " SELECT " +
+                        "   UM_ROLE_NAME, UM_DOMAIN_NAME " +
+                        " FROM "+
+                        "   UM_ROLE_PERMISSION, UM_PERMISSION, UM_DOMAIN " +
+                        " WHERE " +
+                        "   UM_ROLE_PERMISSION.UM_PERMISSION_ID=UM_PERMISSION.UM_ID " +
+                        "   AND " +
+                        "   UM_ROLE_PERMISSION.UM_DOMAIN_ID=UM_DOMAIN.UM_DOMAIN_ID " +
+                        "   AND " +
+                        "   UM_RESOURCE_ID = ? " +
+                        "   AND " +
+                        "   UM_ROLE_PERMISSION.UM_TENANT_ID = ?";
+
+        try (Connection conn = SharedDBUtil.getConnection()) {
+            ps = conn.prepareStatement(sqlQuery);
+            ps.setString(1, permission);
+            ps.setString(2, Integer.toString(tenantId));
+            resultSet = ps.executeQuery();
+            while (resultSet.next()) {
+                String userRoleName = resultSet.getString(Constants.UM_ROLE_NAME);
+                String userRoleDomainName = resultSet.getString(Constants.UM_DOMAIN_NAME);
+                UserRoleFromPermissionDTO userRoleFromPermissionDTO = new UserRoleFromPermissionDTO();
+                userRoleFromPermissionDTO.setUserRoleName(userRoleName);
+                userRoleFromPermissionDTO.setUserRoleDomainName(userRoleDomainName);
+                userRoleFromPermissionList.add(userRoleFromPermissionDTO);
+
+                log.info("User role name: " + userRoleName + ", User domain name: " + userRoleDomainName
+                        + " retrieved for " + tenantId);
+            }
+        } catch (SQLException e) {
+            throw new APIMigrationException("Failed to get Roles matching the permission " + permission +
+                    " and tenant " + tenantId, e);
+        }
+        return userRoleFromPermissionList;
+    }
+
+    /**
+     * Method to get the instance of the SharedDAO.
+     *
+     * @return {@link SharedDAO} instance
+     */
+    public static SharedDAO getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SharedDAO();
+        }
+        return INSTANCE;
+    }
+}

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dto/UserRoleFromPermissionDTO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dto/UserRoleFromPermissionDTO.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.dto;
+
+import java.io.Serializable;
+
+/**
+ * This class represent the User Role From Permission DTO.
+ */
+public class UserRoleFromPermissionDTO implements Serializable {
+
+    private String userRoleName;
+    private String userRoleDomainName;
+
+    public String getUserRoleName() {
+        return userRoleName;
+    }
+
+    public void setUserRoleName(String userRoleName) {
+        this.userRoleName = userRoleName;
+    }
+
+    public String getUserRoleDomainName() {
+        return userRoleDomainName;
+    }
+
+    public void setUserRoleDomainName(String userRoleDomainName) {
+        this.userRoleDomainName = userRoleDomainName;
+    }
+}

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -63,6 +63,7 @@ public class Constants {
     public static final String ARG_OPTIONS_MIGRATE_THROTTLING = "migrateThrottling";
     public static final String ARG_OPTIONS_DEPLOY_POLICIES = "deployPolicies";
     public static final String ARG_POPULATE_SPAPP = "populateSPAPP";
+    public static final String ARG_POPULATE_SCOPE_ROLE_MAPPING = "populateScopeRoleMapping";
 
     // Synapse configuration related
     public static final String SYNAPSE_API_ROOT_ELEMENT = "api";
@@ -285,7 +286,9 @@ public class Constants {
     public static final String AM_POLICY_APPLICATION = "AM_POLICY_APPLICATION";
     public static final String AM_API_THROTTLE_POLICY = "AM_API_THROTTLE_POLICY";
 
-
+    // Table field names
+    public static final String UM_ROLE_NAME = "UM_ROLE_NAME";
+    public static final String UM_DOMAIN_NAME = "UM_DOMAIN_NAME";
 
     public static final String TIER_DESCRIPTION = "Allows {0} request per minute";
     public static final String TIER_API_LEVEL = "apiLevel";
@@ -307,5 +310,11 @@ public class Constants {
     public static final String API_OVERVIEW_VISIBLE_ROLES = "overview_visibleRoles";
     public static final String API_OVERVIEW_TYPE = "overview_type";
 
+    // User domain names
+    public static final String USER_DOMAIN_INTERNAL = "Internal";
 
+    // User role names
+    public static final String CREATOR_ROLE = "Internal/creator";
+    public static final String PUBLISHER_ROLE = "Internal/publisher";
+    public static final String SUBSCRIBER_ROLE = "Internal/subscriber";
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -65,6 +65,12 @@ public class RegistryServiceImpl implements RegistryService {
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenant.getDomain(), true);
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenant.getId(), true);
+            try {
+                APIUtil.loadTenantRegistry(tenant.getId());
+            } catch (RegistryException e) {
+                log.error("Could not load tenant registry for tenant " + tenant.getId() + '('
+                        + tenant.getDomain() + ')', e);
+            }
             this.tenant = tenant;
         }
     }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/SharedDBUtil.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/SharedDBUtil.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.config.RealmConfigXMLProcessor;
+import org.wso2.carbon.user.core.util.DatabaseUtil;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public final class SharedDBUtil {
+
+    private static final Log log = LogFactory.getLog(SharedDBUtil.class);
+    private static volatile DataSource dataSource = null;
+
+    /**
+     * Initializes the data source
+     *
+     * @throws APIMigrationException if an error occurs while building realm configuration from file
+     */
+    public static void initialize() throws APIMigrationException {
+        RealmConfiguration realmConfig;
+        try {
+            realmConfig = new RealmConfigXMLProcessor().buildRealmConfigurationFromFile();
+            dataSource = DatabaseUtil.getRealmDataSource(realmConfig);
+        } catch (UserStoreException e) {
+            throw new APIMigrationException("Error while building realm configuration from file", e);
+        }
+    }
+
+    /**
+     * Utility method to get a new database connection
+     *
+     * @return Connection
+     * @throws APIMigrationException if failed to get Connection
+     */
+    public static Connection getConnection() throws APIMigrationException {
+        try {
+            if (dataSource != null) {
+                return dataSource.getConnection();
+            }
+        } catch (SQLException e) {
+            throw new APIMigrationException("Failed to get Connection.", e);
+        }
+        throw new APIMigrationException("Data source is not configured properly.");
+    }
+}


### PR DESCRIPTION
## Purpose
In API Manager 3.1.0, login flow is changed with role base access control where user should have respective roles to access Publisher and Developer Portal. Since 3.1.0 UI depends completely on REST APIs, authentication to access different components solely depends on the scope-role mapping defined in registry file tenant-conf.json.

By default, the scope-role mapping is added only for the internal roles such as Internal/publisher, Internal/creator and Internal/subscriber. If there are any custom roles defined for API Creator, API Publisher, API Subscriber and Admin, those roles should be configured under relevant scopes. Currently, we suggest to do this manually, but if a particular customer has a large number of roles this might be a tedious task to do.

So, the purpose of this PR is to **automate the task** of adding scope role mapping to the tenant-conf.json.

## Goals
Update the migration client by adding the functionality to populate scope role mapping and add those to the tenant-conf.json of each tenant.

## Approach
1. Introduced a new flag named **-DpopulateScopeRoleMapping**.
2. If this flag is specified or any migration happens from 2.x to 3.1.0, the following steps will happen.
    For each tenant,
   1. Retrieve the **user role names** and **domain names** for the permissions API Create, API Publish and API Subscribe.
   2. Retrieve the tenant-conf.json for the particular tenant.
   3. Create the **RoleMappings** field if it does not exist in the tenant-conf.json. 
   4. Update the **RoleMappings** field with the key-value pairs. Keys are Internal/creator, Internal/publisher and Internal/subscriber. Values for the keys are accordingly, the user role names (where the domain names are added to the front) who has API Create, API Publish and API Subscribe permissions.
       Example:- 
       ```
        "RoleMappings": {
            "Internal/creator": "Internal/creator,testrole1,testrole2",
            "Internal/publsher": "Internal/publisher,testrole3,testrole1",
            "Internal/subscriber": "Internal/subscriber,testrole4,testrole5"
        }
        ```
    5. Update the tenant-conf.json of the particular tenant with the modified tenant-conf.json.

Apart from the above-stated tasks, I have updated the carbon.apimgt.version and carbon.governance.version temporarily. Those should be fixed https://github.com/wso2/product-apim/issues/8322.

## User stories
- When a customer is doing a migration using the below command to do the migration.
  (In Linux/Mac OS)
  ```
  sh wso2server.sh -DmigrateFromVersion=2.x.x
  ```
  (In Windows)
  ```
  wso2server.bat -DmigrateFromVersion=2.x.x
  ```

- If a customer has already done a migration and facing the difficulty to manually do the scope role mapping, he/she can use the below command to start the server and the migration client will automatically do that.
  (In Linux/Mac OS)
  ```
  sh wso2server.sh -DpopulateScopeRoleMapping
  ```
  (In Windows)
  ```
  wso2server.bat -DpopulateScopeRoleMapping
  ```

## Documentation
Documentation changes should be done by removing the statements about manually updating the scope role mappings and should update the .jar related to migration client.

## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS