### PR TITLE
[3.1.0] Fixing scope role mapping error in migration client

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
@@ -64,7 +64,7 @@ public class SharedDAO {
              PreparedStatement ps = conn.prepareStatement(sqlQuery);) {
 
             ps.setString(1, permission);
-            ps.setString(2, Integer.toString(tenantId));
+            ps.setInt(2, tenantId);
 
             try (ResultSet resultSet = ps.executeQuery();) {
                 while (resultSet.next()) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/8594

## Goals
Conduct scope role migration without errors based on the database type

## Approach
Changed the **setString** function in SharedDao.java to **setInt** to eliminate errors which occur due to various database types (eg:- postgres). 

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS