### PR TITLE
Modifying the migration client of APIM 3.2.0 to populate "RoleMappings" with admin role mappings

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
@@ -118,21 +118,21 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
                 // Extract the RESTAPIScopes object
                 JSONObject restAPIScopes = (JSONObject) tenantConf.get(APIConstants.REST_API_SCOPES_CONFIG);
                 if (restAPIScopes != null) {
-                    JSONArray scopesArray = (JSONArray)restAPIScopes.get(Constants.SCOPE);
+                    JSONArray scopesArray = (JSONArray) restAPIScopes.get(Constants.SCOPE);
                     for (Object scopeMapping : scopesArray) {
                         JSONObject mapping = (JSONObject) scopeMapping;
-                        String scopeName = (String)mapping.get(Constants.NAME);
+                        String scopeName = (String) mapping.get(Constants.NAME);
                         if (scopeListAllowedForCreator.contains(scopeName)) {
-                            String roleList = (String)mapping.get(Constants.ROLES);
-                            if (!roleList.contains(Constants.INTERNAL_CREATOR_ROLE)) {
-                                roleList = roleList + ", " + Constants.INTERNAL_CREATOR_ROLE;
+                            String roleList = (String) mapping.get(Constants.ROLES);
+                            if (!roleList.contains(Constants.CREATOR_ROLE)) {
+                                roleList = roleList + ", " + Constants.CREATOR_ROLE;
                                 mapping.put(Constants.ROLES, roleList);
                             }
                         }
                         if (scopeListAllowedForPublisher.contains(scopeName)) {
-                            String roleList = (String)mapping.get(Constants.ROLES);
-                            if (!roleList.contains(Constants.INTERNAL_PUBLISHER_ROLE)) {
-                                roleList = roleList + ", " + Constants.INTERNAL_PUBLISHER_ROLE;
+                            String roleList = (String) mapping.get(Constants.ROLES);
+                            if (!roleList.contains(Constants.PUBLISHER_ROLE)) {
+                                roleList = roleList + ", " + Constants.PUBLISHER_ROLE;
                                 mapping.put(Constants.ROLES, roleList);
                             }
                         }
@@ -143,7 +143,7 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
                 String formattedTenantConf = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tenantConf);
                 APIUtil.updateTenantConf(formattedTenantConf, tenant.getDomain());
                 log.info("Updated scope roles of tenant-conf.json for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')'
-                        + "\n" + formattedTenantConf );
+                        + "\n" + formattedTenantConf);
             } catch (APIManagementException e) {
                 log.error("Error while updating scope role mappings in tenant-conf.json. ", e);
             } catch (JsonProcessingException e) {
@@ -167,7 +167,6 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
     /**
      * This method is used to update the scopes of the user roles which will be retrieved based on the
      * permissions assigned.
-     *
      */
     public void populateRoleMappingWithUserRoles() throws APIMigrationException {
         log.info("Updating User Roles based on Permissions started.");
@@ -190,6 +189,11 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
                 List<UserRoleFromPermissionDTO> userRolesListWithSubscribePermission = SharedDAO.getInstance()
                         .getRoleNamesMatchingPermission(APIConstants.Permissions.API_SUBSCRIBE, tenant.getId());
 
+                // Retrieve user roles which has admin permissions
+                List<UserRoleFromPermissionDTO> userRolesListWithAdminPermission = SharedDAO.getInstance()
+                        .getRoleNamesMatchingPermissions(makePermissionsStringByEscapingSlash(
+                                APIConstants.Permissions.APIM_ADMIN, "/permission"), tenant.getId());
+
                 // Retrieve the tenant-conf.json of the corresponding tenant
                 JSONObject tenantConf = APIUtil.getTenantConfig(tenant.getDomain());
 
@@ -202,14 +206,15 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
                 }
 
                 createOrUpdateRoleMappingsField(roleMappings, userRolesListWithCreatePermission,
-                        userRolesListWithPublishPermission, userRolesListWithSubscribePermission);
+                        userRolesListWithPublishPermission, userRolesListWithSubscribePermission,
+                        userRolesListWithAdminPermission);
 
                 ObjectMapper mapper = new ObjectMapper();
                 String formattedTenantConf = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tenantConf);
 
                 APIUtil.updateTenantConf(formattedTenantConf, tenant.getDomain());
                 log.info("Updated tenant-conf.json for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')'
-                        + "\n" + formattedTenantConf );
+                        + "\n" + formattedTenantConf);
 
                 log.info("End updating user roles for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')');
             } catch (APIManagementException e) {
@@ -225,31 +230,29 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
 
     /**
      * This method is used to retrieve user roles as a comma separated string
-     *
      */
     private String getUserRoleArrayAsString(List<UserRoleFromPermissionDTO> userRoleFromPermissionDTOs) {
         List<String> updatedUserRoles = new ArrayList<>();
-        for (UserRoleFromPermissionDTO userRoleFromPermissionDTO: userRoleFromPermissionDTOs) {
+        for (UserRoleFromPermissionDTO userRoleFromPermissionDTO : userRoleFromPermissionDTOs) {
             String userRoleName = userRoleFromPermissionDTO.getUserRoleName();
             String domainName = userRoleFromPermissionDTO.getUserRoleDomainName();
             updatedUserRoles.add(addDomainToName(userRoleName, domainName));
         }
-        return StringUtils.join( updatedUserRoles, ",");
+        return StringUtils.join(updatedUserRoles, ",");
     }
 
     /**
      * This method is used to retrieve merged existing role mappings and new user roles
-     *
      */
     private String getMergedUserRolesAndRoleMappings(List<UserRoleFromPermissionDTO> userRoles, String roleMappings) {
         // Splitting
         ArrayList<String> roleMappingsArray = new ArrayList<String>(Arrays.asList(StringUtils.
-                split(roleMappings,",")));
+                split(roleMappings, ",")));
         // Trimming
         for (int i = 0; i < roleMappingsArray.size(); i++)
             roleMappingsArray.set(i, roleMappingsArray.get(i).trim());
 
-        for (UserRoleFromPermissionDTO userRole: userRoles) {
+        for (UserRoleFromPermissionDTO userRole : userRoles) {
             String domainNameAddedUserRoleName = addDomainToName(userRole.getUserRoleName(), userRole.getUserRoleDomainName());
             if (!roleMappingsArray.contains(domainNameAddedUserRoleName)) {
                 roleMappingsArray.add(domainNameAddedUserRoleName);
@@ -257,15 +260,16 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
         }
         return StringUtils.join(roleMappingsArray, ",");
     }
+
     /**
      * This method is used to add the fields (Internal/creator, Internal/publisher and Internal/subscriber) and
      * assign the created user roles list as values to the object
-     *
      */
     private void createOrUpdateRoleMappingsField(JSONObject roleMappings,
                                                  List<UserRoleFromPermissionDTO> userRolesListWithCreatePermission,
                                                  List<UserRoleFromPermissionDTO> userRolesListWithPublishPermission,
-                                                 List<UserRoleFromPermissionDTO> userRolesListWithSubscribePermission) {
+                                                 List<UserRoleFromPermissionDTO> userRolesListWithSubscribePermission,
+                                                 List<UserRoleFromPermissionDTO> userRolesListWithAdminPermission) {
         if (roleMappings.get(Constants.CREATOR_ROLE) == null) {
             roleMappings.put(Constants.CREATOR_ROLE,
                     getUserRoleArrayAsString(userRolesListWithCreatePermission));
@@ -295,11 +299,20 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
                     getMergedUserRolesAndRoleMappings(userRolesListWithSubscribePermission,
                             String.valueOf(roleMappings.get(Constants.SUBSCRIBER_ROLE))));
         }
+
+        if (roleMappings.get(Constants.ADMIN_ROLE) == null) {
+            roleMappings.put(Constants.ADMIN_ROLE,
+                    getUserRoleArrayAsString(userRolesListWithAdminPermission));
+        } else {
+            roleMappings.put(
+                    Constants.ADMIN_ROLE,
+                    getMergedUserRolesAndRoleMappings(userRolesListWithAdminPermission,
+                            String.valueOf(roleMappings.get(Constants.ADMIN_ROLE))));
+        }
     }
 
     /**
      * This method is used to retrieve a string where the domain name is added in front of the user role name
-     *
      */
     private String addDomainToName(String userRoleName, String domainName) {
         if (StringUtils.equals(domainName.toLowerCase(), Constants.USER_DOMAIN_INTERNAL.toLowerCase())) {
@@ -309,5 +322,27 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
         } else {
             return UserCoreUtil.addDomainToName(userRoleName, domainName);
         }
+    }
+
+    /**
+     * This method is used to retrieve a string with multiple permissions by escaping slashes
+     * Example: If you provide "/permission/mypermission/" as startPermission and "/permission" as endPermission
+     * this will produces a string as "'/permission/mypermission/', '/permission/mypermission', '/permission/,
+     * '/permission'"
+     */
+    private String makePermissionsStringByEscapingSlash(String startPermission, String endPermission) {
+        StringBuilder permissions = new StringBuilder();
+        permissions.append("'").append(startPermission).append("', ");
+        for (int i = startPermission.length() - 1; i >= 0; i--) {
+            if (!StringUtils.equals(startPermission.substring(0, i + 1), endPermission)) {
+                if (startPermission.charAt(i) == '/') {
+                    permissions.append("'").append(startPermission, 0, i + 1).append("', ");
+                    permissions.append("'").append(startPermission, 0, i).append("', ");
+                }
+            } else {
+                break;
+            }
+        }
+        return StringUtils.chop(permissions.toString().trim());
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
@@ -88,6 +88,50 @@ public class SharedDAO {
         return userRoleFromPermissionList;
     }
 
+    public List<UserRoleFromPermissionDTO> getRoleNamesMatchingPermissions(String permissions, int tenantId) throws APIMigrationException {
+        List<UserRoleFromPermissionDTO> userRoleFromPermissionList = new ArrayList<UserRoleFromPermissionDTO>();
+
+        String sqlQuery =
+                " SELECT " +
+                "   DISTINCT UM_ROLE_NAME, UM_DOMAIN_NAME " +
+                " FROM " +
+                "   UM_ROLE_PERMISSION, UM_PERMISSION, UM_DOMAIN " +
+                " WHERE " +
+                "   UM_ROLE_PERMISSION.UM_PERMISSION_ID=UM_PERMISSION.UM_ID " +
+                "   AND " +
+                "   UM_ROLE_PERMISSION.UM_DOMAIN_ID=UM_DOMAIN.UM_DOMAIN_ID " +
+                "   AND " +
+                "   UM_RESOURCE_ID IN (" + permissions + ")" +
+                "   AND " +
+                "   UM_ROLE_PERMISSION.UM_TENANT_ID = ?";
+
+        try (Connection conn = SharedDBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sqlQuery);) {
+
+            ps.setInt(1, tenantId);
+
+            try (ResultSet resultSet = ps.executeQuery();) {
+                while (resultSet.next()) {
+                    String userRoleName = resultSet.getString(Constants.UM_ROLE_NAME);
+                    String userRoleDomainName = resultSet.getString(Constants.UM_DOMAIN_NAME);
+                    UserRoleFromPermissionDTO userRoleFromPermissionDTO = new UserRoleFromPermissionDTO();
+                    userRoleFromPermissionDTO.setUserRoleName(userRoleName);
+                    userRoleFromPermissionDTO.setUserRoleDomainName(userRoleDomainName);
+                    userRoleFromPermissionList.add(userRoleFromPermissionDTO);
+
+                    log.info("User role name: " + userRoleName + ", User domain name: " + userRoleDomainName
+                            + " retrieved for " + tenantId);
+                }
+            } catch (SQLException e) {
+                throw new APIMigrationException("Failed to get the result set.", e);
+            }
+        } catch (SQLException e) {
+            throw new APIMigrationException("Failed to get Roles matching the permission " + permissions +
+                    " and tenant " + tenantId, e);
+        }
+        return userRoleFromPermissionList;
+    }
+
     /**
      * Method to get the instance of the SharedDAO.
      *

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -318,6 +318,7 @@ public class Constants {
     public static final String CREATOR_ROLE = "Internal/creator";
     public static final String PUBLISHER_ROLE = "Internal/publisher";
     public static final String SUBSCRIBER_ROLE = "Internal/subscriber";
+    public static final String ADMIN_ROLE = "admin";
 
     // Rest API Scopes
     public static final String API_PUBLISH_SCOPE = "apim:api_publish";
@@ -329,6 +330,4 @@ public class Constants {
     public static final String SCOPE = "Scope";
     public static final String NAME = "Name";
     public static final String ROLES = "Roles";
-    public static final String INTERNAL_CREATOR_ROLE = "Internal/creator";
-    public static final String INTERNAL_PUBLISHER_ROLE = "Internal/publisher";
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9003

## Goals
Update the migration client by adding the functionality to populate scope role mapping for custom admin roles and add those to the tenant-conf.json of each tenant.

## Approach
For each tenant,
   1. Retrieved the **admin user role names** and **domain names** for the permissions '/permission/admin/manage/apim_admin', '/permission/admin/manage/', '/permission/admin/manage', '/permission/admin/', '/permission/admin', '/permission/', '/permission'.
   2. As done in https://github.com/wso2-extensions/apim-migration-resources/pull/10, updated the **RoleMappings** field with admin and the corresponding role names retrieved in the above step.
       Example:- 
       ```
        "RoleMappings": {
            "Internal/creator": "Internal/creator,testrole1,testrole2",
            "Internal/publsher": "Internal/publisher,testrole3,testrole1",
            "Internal/subscriber": "Internal/subscriber,testrole4,testrole5",
            "admin": "admin,custom_admin"
        }
        ```
   3. Update the tenant-conf.json of the particular tenant with the modified tenant-conf.json.

## User stories
Same use case covered in https://github.com/wso2-extensions/apim-migration-resources/pull/10

## Related PRs
https://github.com/wso2-extensions/apim-migration-resources/pull/10

## Documentation
Documentation changes should be done by updating the .jar related to migration client.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS