### PR TITLE
Modifying the migration client of APIM 3.1.0 to populate "RoleMappings" with admin role mappings

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -317,4 +317,8 @@ public class Constants {
     public static final String CREATOR_ROLE = "Internal/creator";
     public static final String PUBLISHER_ROLE = "Internal/publisher";
     public static final String SUBSCRIBER_ROLE = "Internal/subscriber";
+    public static final String ADMIN_ROLE = "admin";
+
+    //Permission Strings
+    public static final String APIM_ADMIN = "/permission/admin/manage/apim_admin";
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9003
Backporting https://github.com/wso2-extensions/apim-migration-resources/pull/45

## Goals
Update the migration client by adding the functionality to populate scope role mapping for custom admin roles and add those to the tenant-conf.json of each tenant.

## Approach
For each tenant,
   1. Retrieved the **admin user role names** and **domain names** for the permissions '/permission/admin/manage/apim_admin', '/permission/admin/manage/', '/permission/admin/manage', '/permission/admin/', '/permission/admin', '/permission/', '/permission'.
   2. As done in https://github.com/wso2-extensions/apim-migration-resources/pull/10, updated the **RoleMappings** field with admin and the corresponding role names retrieved in the above step.
       Example:- 
       ```
        "RoleMappings": {
            "Internal/creator": "Internal/creator,testrole1,testrole2",
            "Internal/publsher": "Internal/publisher,testrole3,testrole1",
            "Internal/subscriber": "Internal/subscriber,testrole4,testrole5",
            "admin": "admin,custom_admin"
        }
        ```
   3. Update the tenant-conf.json of the particular tenant with the modified tenant-conf.json.

## User stories
Same use case covered in https://github.com/wso2-extensions/apim-migration-resources/pull/10

## Related PRs
https://github.com/wso2-extensions/apim-migration-resources/pull/10

## Documentation
Documentation changes should be done by updating the .jar related to migration client.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS