### PR TITLE
 [3.1.0 Migration] Assigning the correct type to SOAPTOREST APIs during the registry migration

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -309,6 +309,11 @@ public class Constants {
     public static final String API_OVERVIEW_VISIBILITY = "overview_visibility";
     public static final String API_OVERVIEW_VISIBLE_ROLES = "overview_visibleRoles";
     public static final String API_OVERVIEW_TYPE = "overview_type";
+    public static final String API_OVERVIEW_NAME = "overview_name";
+    public static final String API_OVERVIEW_VERSION = "overview_version";
+    public static final String API_OVERVIEW_PROVIDER = "overview_provider";
+    public static final String API_TYPE_SOAPTOREST = "SOAPTOREST";
+    public static final String API_TYPE_HTTP = "HTTP";
 
     // User domain names
     public static final String USER_DOMAIN_INTERNAL = "Internal";

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -411,7 +411,7 @@ public class RegistryServiceImpl implements RegistryService {
             Registry registry = getGovernanceRegistry();
             GenericArtifactManager artifactManager = APIUtil.getArtifactManager(registry, APIConstants.API_KEY);
             boolean isResourceUpdated = false;
-            String overview_type = artifact.getAttribute(Constants.API_OVERVIEW_TYPE);
+            String overviewType = artifact.getAttribute(Constants.API_OVERVIEW_TYPE);
             if (SOAPOperationBindingUtils.isSOAPToRESTApi(artifact.getAttribute(Constants.API_OVERVIEW_NAME),
                     artifact.getAttribute(Constants.API_OVERVIEW_VERSION),
                     artifact.getAttribute(Constants.API_OVERVIEW_PROVIDER))) {
@@ -419,11 +419,11 @@ public class RegistryServiceImpl implements RegistryService {
                     log.debug("API at " + resourcePath + "is a SOAPTOREST API, hence adding the overview_type" +
                             " as SOAPTOREST for that API resource.");
                 }
-                overview_type = Constants.API_TYPE_SOAPTOREST;
-                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, overview_type);
+                overviewType = Constants.API_TYPE_SOAPTOREST;
+                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, overviewType);
                 isResourceUpdated = true;
             }
-            if (overview_type == null || overview_type.trim().isEmpty()){
+            if (overviewType == null || overviewType.trim().isEmpty()){
                 if (log.isDebugEnabled()) {
                     log.debug("API at " + resourcePath + "did not have property : " + Constants.API_OVERVIEW_TYPE
                             + ", hence adding the default value - HTTP for that API resource.");

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPOperationBindingUtils;
 import org.wso2.carbon.apimgt.migration.client.internal.ServiceHolder;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.governance.api.exception.GovernanceException;
@@ -411,12 +412,23 @@ public class RegistryServiceImpl implements RegistryService {
             GenericArtifactManager artifactManager = APIUtil.getArtifactManager(registry, APIConstants.API_KEY);
             boolean isResourceUpdated = false;
             String overview_type = artifact.getAttribute(Constants.API_OVERVIEW_TYPE);
+            if (SOAPOperationBindingUtils.isSOAPToRESTApi(artifact.getAttribute(Constants.API_OVERVIEW_NAME),
+                    artifact.getAttribute(Constants.API_OVERVIEW_VERSION),
+                    artifact.getAttribute(Constants.API_OVERVIEW_PROVIDER))) {
+                if (log.isDebugEnabled()) {
+                    log.debug("API at " + resourcePath + "is a SOAPTOREST API, hence adding the overview_type" +
+                            " as SOAPTOREST for that API resource.");
+                }
+                overview_type = Constants.API_TYPE_SOAPTOREST;
+                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, overview_type);
+                isResourceUpdated = true;
+            }
             if (overview_type == null || overview_type.trim().isEmpty()){
                 if (log.isDebugEnabled()) {
                     log.debug("API at " + resourcePath + "did not have property : " + Constants.API_OVERVIEW_TYPE
                             + ", hence adding the default value - HTTP for that API resource.");
                 }
-                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, "HTTP");
+                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, Constants.API_TYPE_HTTP);
                 isResourceUpdated = true;
             }
             if (isResourceUpdated) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9076
Backporting https://github.com/wso2-extensions/apim-migration-resources/pull/50

## Goals
Assigning the correct type "SOAPTOREST" to the registry resource.

## Approach
- Modified the registry migration client to check whether a particular API is a SOAPTOREST API.
- If so the overview_type of the registry resource was set to "SOAPTOREST".

## User stories
SOAP to REST conversion logs are visible in the resources in Publisher portal after the migration.

## Test environment
- jdk 1.8.0_251
- Ubuntu 20.04 LTS
- PostgreSQL 12.3