### PR TITLE
[3.2.0 Migration] Adding the missing URL mappings that are required to invoke WS APIs

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
@@ -423,4 +423,33 @@ public class APIMgtDAO {
             throw new APIMigrationException("SQLException when executing: ".concat(UPDATE_TOKEN_TYPE_TO_JWT), e);
         }
     }
+
+    /**
+     * This method is used to insert data to add default URL Mappings of WS APIs
+     * @param apiId
+     * @throws APIMigrationException
+     */
+    public void addURLTemplatesForWSAPIs(int apiId) throws APIMigrationException {
+        if (apiId == -1) {
+            //application addition has failed
+            return;
+        }
+
+        String sqlQuery = "INSERT INTO AM_API_URL_MAPPING (API_ID,HTTP_METHOD,AUTH_SCHEME,URL_PATTERN) VALUES (?,?,?,?)";
+
+        try (Connection conn = APIMgtDBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sqlQuery)) {
+            for (String httpVerb: Constants.HTTP_DEFAULT_METHODS) {
+                ps.setInt(1, apiId);
+                ps.setString(2, httpVerb);
+                ps.setString(3, Constants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN);
+                ps.setString(4, Constants.API_DEFAULT_URI_TEMPLATE);
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        } catch (SQLException e) {
+            throw new APIMigrationException("Error while adding URL template(s) to the database " + e);
+        }
+    }
+
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
@@ -227,6 +227,10 @@ public class APIMgtDAO {
                 preparedStatement.setInt(1, newScopeId);
                 preparedStatement.setInt(2, scopeId);
                 preparedStatement.executeUpdate();
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw new APIMigrationException("SQLException when executing: ".concat(UPDATE_SCOPE_ID_IN_RESOURCE), e);
             }
         } catch (SQLException e) {
             throw new APIMigrationException("SQLException when executing: ".concat(UPDATE_SCOPE_ID_IN_RESOURCE), e);
@@ -339,6 +343,7 @@ public class APIMgtDAO {
     public void addDataToResourceScopeMapping(List<AMAPIResourceScopeMappingDTO> resourceScopeMappingDTOS)
             throws APIMigrationException {
         try (Connection conn = APIMgtDBUtil.getConnection()) {
+            conn.setAutoCommit(false);
             try (PreparedStatement psAddResourceScope =
                          conn.prepareStatement(INSERT_INTO_AM_API_RESOURCE_SCOPE_MAPPING)) {
                 for (AMAPIResourceScopeMappingDTO resourceScopeMappingDTO : resourceScopeMappingDTOS) {
@@ -348,6 +353,10 @@ public class APIMgtDAO {
                     psAddResourceScope.addBatch();
                 }
                 psAddResourceScope.executeBatch();
+                conn.commit();
+            } catch (SQLException ex) {
+                conn.rollback();
+                throw new APIMigrationException("Failed to add data to AM_API_RESOURCE_SCOPE_MAPPING table : ", ex);
             }
         } catch (SQLException ex) {
             throw new APIMigrationException("Failed to add data to AM_API_RESOURCE_SCOPE_MAPPING table : ", ex);
@@ -419,8 +428,11 @@ public class APIMgtDAO {
                 preparedStatement.setString(1, "JWT");
                 preparedStatement.setString(2, consumerKey);
                 preparedStatement.executeUpdate();
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw new APIMigrationException("SQLException when executing: ".concat(UPDATE_TOKEN_TYPE_TO_JWT), e);
             }
-
         } catch (SQLException e) {
             throw new APIMigrationException("SQLException when executing: ".concat(UPDATE_TOKEN_TYPE_TO_JWT), e);
         }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/SharedDAO.java
@@ -61,12 +61,12 @@ public class SharedDAO {
                 "   UM_ROLE_PERMISSION.UM_TENANT_ID = ?";
 
         try (Connection conn = SharedDBUtil.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sqlQuery);) {
+             PreparedStatement ps = conn.prepareStatement(sqlQuery)) {
 
             ps.setString(1, permission);
             ps.setInt(2, tenantId);
 
-            try (ResultSet resultSet = ps.executeQuery();) {
+            try (ResultSet resultSet = ps.executeQuery()) {
                 while (resultSet.next()) {
                     String userRoleName = resultSet.getString(Constants.UM_ROLE_NAME);
                     String userRoleDomainName = resultSet.getString(Constants.UM_DOMAIN_NAME);
@@ -106,11 +106,11 @@ public class SharedDAO {
                 "   UM_ROLE_PERMISSION.UM_TENANT_ID = ?";
 
         try (Connection conn = SharedDBUtil.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sqlQuery);) {
+             PreparedStatement ps = conn.prepareStatement(sqlQuery)) {
 
             ps.setInt(1, tenantId);
 
-            try (ResultSet resultSet = ps.executeQuery();) {
+            try (ResultSet resultSet = ps.executeQuery()) {
                 while (resultSet.next()) {
                     String userRoleName = resultSet.getString(Constants.UM_ROLE_NAME);
                     String userRoleDomainName = resultSet.getString(Constants.UM_DOMAIN_NAME);

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -306,6 +306,8 @@ public class Constants {
     public static final String PUBLIC_STORE_VISIBILITY = "public";
     public static final String RESTRICTED_STORE_VISIBILITY = "restricted";
     public static final String PRIVATE_STORE_VISIBILITY = "private";
+    public static final String AUTH_APPLICATION_OR_USER_LEVEL_TOKEN = "Any";
+    public static final String API_DEFAULT_URI_TEMPLATE = "/*";
     public static final String API_OVERVIEW_VISIBILITY = "overview_visibility";
     public static final String API_OVERVIEW_VISIBLE_ROLES = "overview_visibleRoles";
     public static final String API_OVERVIEW_TYPE = "overview_type";
@@ -313,8 +315,11 @@ public class Constants {
     public static final String API_OVERVIEW_NAME = "overview_name";
     public static final String API_OVERVIEW_VERSION = "overview_version";
     public static final String API_OVERVIEW_PROVIDER = "overview_provider";
+    public static final String API_OVERVIEW_CONTEXT = "overview_context";
+    public static final String[] HTTP_DEFAULT_METHODS = {"GET", "PUT", "POST", "DELETE", "PATCH"};
     public static final String API_TYPE_SOAPTOREST = "SOAPTOREST";
     public static final String API_TYPE_HTTP = "HTTP";
+    public static final String API_TYPE_WS = "WS";
 
     // User domain names
     public static final String USER_DOMAIN_INTERNAL = "Internal";

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.migration.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -28,7 +29,9 @@ import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPOperationBindingUtils;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.internal.ServiceHolder;
+import org.wso2.carbon.apimgt.migration.dao.APIMgtDAO;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.governance.api.exception.GovernanceException;
 import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
@@ -428,8 +431,14 @@ public class RegistryServiceImpl implements RegistryService {
                     log.debug("API at " + resourcePath + "did not have property : " + Constants.API_OVERVIEW_TYPE
                             + ", hence adding the default value - HTTP for that API resource.");
                 }
-                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, "HTTP");
+                artifact.setAttribute(Constants.API_OVERVIEW_TYPE, Constants.API_TYPE_HTTP);
                 isResourceUpdated = true;
+            }
+            // Add URI Templates for WS APIs, otherwise cannot invoke those after the migration
+            if (StringUtils.equals(overview_type, Constants.API_TYPE_WS)) {
+                int id = Integer.parseInt(APIMgtDAO.getInstance().getAPIID(
+                        artifact.getAttribute(Constants.API_OVERVIEW_CONTEXT)));
+                APIMgtDAO.getInstance().addURLTemplatesForWSAPIs(id);
             }
             if (isResourceUpdated) {
                 artifactManager.updateGenericArtifact(artifact);
@@ -438,6 +447,8 @@ public class RegistryServiceImpl implements RegistryService {
             log.error("Error occurred when updating GenericArtifacts in registry", e);
         } catch (APIManagementException e) {
             log.error("Error occurred when getting artifact manager", e);
+        } catch (APIMigrationException e) {
+            log.error("Error occurred when getting apiId", e);
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9083

## Goals
Adding the URI templates required when invoking WebSocket APIs.

## Approach
- Modified the registry migration client to check whether a particular API is a WS API.
- If so, the URL mappings were added to AM_API_URL_MAPPING tables for that particular API.

## User stories
Users can invoke migrated WS APIs.

## Test environment
- jdk 1.8.0_251
- Ubuntu 20.04 LTS
- PostgreSQL 12.3
- wscat version: 4.0.1