### PR TITLE
Add cross tenant susbcription validation

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -79,6 +79,8 @@ public class APIMMigrationService implements ServerStartupObserver {
         boolean isSPMigration = Boolean.parseBoolean(System.getProperty(APIMStatMigrationConstants.ARG_MIGRATE_SP));
         boolean isSP_APP_Population = Boolean.parseBoolean(System.getProperty(Constants.ARG_POPULATE_SPAPP));
         boolean isScopeRoleMappingPopulation = Boolean.parseBoolean(System.getProperty(Constants.ARG_POPULATE_SCOPE_ROLE_MAPPING));
+        boolean ignoreCrossTenantSubscriptions =
+                Boolean.parseBoolean(System.getProperty(Constants.ARG_IGNORE_CROSS_TENANT_SUBSCRIPTIONS));
 
         try {
             RegistryServiceImpl registryService = new RegistryServiceImpl();
@@ -113,7 +115,7 @@ public class APIMMigrationService implements ServerStartupObserver {
                 scopeRoleMappingPopulation.populateScopeRoleMapping();
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
-                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager);
+                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager, ignoreCrossTenantSubscriptions);
                 migrateFrom310.scopeMigration();
                 migrateFrom310.spMigration();
             } else if (V210.equals(migrateFromVersion) || V220.equals(migrateFromVersion) ||
@@ -129,7 +131,7 @@ public class APIMMigrationService implements ServerStartupObserver {
                 log.info("Starting Migration from API Manager 3.1 to 3.2");
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
-                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager);
+                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager, ignoreCrossTenantSubscriptions);
                 migrateFrom310.scopeMigration();
                 migrateFrom310.spMigration();
                 log.info("Migrated Successfully to 3.2");
@@ -140,7 +142,7 @@ public class APIMMigrationService implements ServerStartupObserver {
             } else if(V310.equals(migrateFromVersion) || V300.equals(migrateFromVersion)) {
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
-                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager);
+                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager, ignoreCrossTenantSubscriptions);
                 migrateFrom310.registryResourceMigration();
                 migrateFrom310.scopeMigration();
                 migrateFrom310.spMigration();

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -113,6 +113,7 @@ public class APIMMigrationService implements ServerStartupObserver {
                 scopeRoleMappingPopulation.populateScopeRoleMapping();
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
+                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager);
                 migrateFrom310.scopeMigration();
                 migrateFrom310.spMigration();
             } else if (V210.equals(migrateFromVersion) || V220.equals(migrateFromVersion) ||
@@ -128,6 +129,7 @@ public class APIMMigrationService implements ServerStartupObserver {
                 log.info("Starting Migration from API Manager 3.1 to 3.2");
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
+                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager);
                 migrateFrom310.scopeMigration();
                 migrateFrom310.spMigration();
                 log.info("Migrated Successfully to 3.2");
@@ -138,6 +140,7 @@ public class APIMMigrationService implements ServerStartupObserver {
             } else if(V310.equals(migrateFromVersion) || V300.equals(migrateFromVersion)) {
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
+                migrateFrom310.checkCrossTenantAPISubscriptions(tenantManager);
                 migrateFrom310.registryResourceMigration();
                 migrateFrom310.scopeMigration();
                 migrateFrom310.spMigration();

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
@@ -1234,6 +1234,7 @@ public class MigrateFrom110to200 extends MigrationClientBase implements Migratio
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
@@ -1232,4 +1232,8 @@ public class MigrateFrom110to200 extends MigrationClientBase implements Migratio
             throw new APIManagementException(msg, e);
         }
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
@@ -1513,4 +1513,8 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
         }
 
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
@@ -1515,6 +1515,7 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
@@ -852,6 +852,7 @@ public class MigrateFrom19to110 extends MigrationClientBase implements Migration
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
@@ -850,4 +850,8 @@ public class MigrateFrom19to110 extends MigrationClientBase implements Migration
     @Override
     public void updateScopeRoleMappings() throws APIMigrationException {
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
@@ -93,6 +93,7 @@ public class MigrateFrom200 extends MigrationClientBase implements MigrationClie
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
@@ -91,4 +91,8 @@ public class MigrateFrom200 extends MigrationClientBase implements MigrationClie
     @Override
     public void updateScopeRoleMappings() throws APIMigrationException {
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
@@ -181,6 +181,10 @@ public class MigrateFrom200to210 extends MigrationClientBase implements Migratio
         }
     }
 
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
+
     private static boolean isEmpty(String str) {
         return str == null || str.length() == 0;
     }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
@@ -182,7 +182,8 @@ public class MigrateFrom200to210 extends MigrationClientBase implements Migratio
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 
     private static boolean isEmpty(String str) {

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
@@ -96,4 +96,8 @@ public class MigrateFrom210 extends MigrationClientBase implements MigrationClie
     @Override
     public void updateScopeRoleMappings() throws APIMigrationException {
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
@@ -98,6 +98,7 @@ public class MigrateFrom210 extends MigrationClientBase implements MigrationClie
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
@@ -232,13 +232,17 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
 
         APIMgtDAO apiMgtDAO = APIMgtDAO.getInstance();
         if (apiMgtDAO.isCrossTenantAPISubscriptionsExist(tenantManager)) {
             log.error("Cross tenant subscriptions exist. " +
-                    "Please contact WSO2 team for the migration");
-            System.exit(1);
+                    "Please contact WSO2 team for the migration. Flag 'ignoreCrossTenantSubscriptions': "
+                            .concat(String.valueOf(ignoreCrossTenantSubscriptions)));
+            if (!ignoreCrossTenantSubscriptions) {
+                System.exit(1);
+            }
         } else {
             log.info("No cross tenant subscriptions exist");
         }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
@@ -230,4 +230,17 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
             }
         }
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+
+        APIMgtDAO apiMgtDAO = APIMgtDAO.getInstance();
+        if (apiMgtDAO.isCrossTenantAPISubscriptionsExist(tenantManager)) {
+            log.error("Cross tenant subscriptions exist. " +
+                    "Please contact WSO2 team for the migration");
+            System.exit(1);
+        } else {
+            log.info("No cross tenant subscriptions exist");
+        }
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
@@ -123,9 +123,11 @@ public interface MigrationClient {
      * This method is used to check the existence of cross tenant subscriptions
      * during the migrations to 3.2
      *
-     * @param tenantManager Tenant Manager
+     * @param tenantManager                  Tenant Manager
+     * @param ignoreCrossTenantSubscriptions Whether to ignore the validation and proceed with migration
      * @throws APIMigrationException
      */
-    void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException;
+    void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException;
 
-    }
+}

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.apimgt.migration.client;
 
 import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.sp_migration.APIMStatMigrationException;
+import org.wso2.carbon.user.core.tenant.TenantManager;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -117,4 +118,14 @@ public interface MigrationClient {
      * @throws APIMigrationException
      */
     void updateScopeRoleMappings() throws APIMigrationException;
-}
+
+    /**
+     * This method is used to check the existence of cross tenant subscriptions
+     * during the migrations to 3.2
+     *
+     * @param tenantManager Tenant Manager
+     * @throws APIMigrationException
+     */
+    void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException;
+
+    }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
@@ -423,6 +423,7 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
@@ -421,4 +421,8 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
         }
         return tenantConfJson;
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
@@ -190,4 +190,8 @@ public class APIMStatMigrationClient extends MigrationClientBase implements Migr
     @Override
     public void updateScopeRoleMappings() throws APIMigrationException {
     }
+
+    @Override
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
@@ -192,6 +192,7 @@ public class APIMStatMigrationClient extends MigrationClientBase implements Migr
     }
 
     @Override
-    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager) throws APIMigrationException {
+    public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
+            throws APIMigrationException {
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
@@ -44,6 +44,12 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
 public class APIMgtDAO {
     private static final Log log = LogFactory.getLog(APIMgtDAO.class);
     private static APIMgtDAO INSTANCE = null;
@@ -93,6 +99,15 @@ public class APIMgtDAO {
             " PROPERTY_VALUE = ? WHERE PROPERTY_KEY  = 'tokenType' AND CONSUMER_KEY = ?";
     private static String INSERT_URL_MAPPINGS_FOR_WS_APIS =
             "INSERT INTO AM_API_URL_MAPPING (API_ID,HTTP_METHOD,AUTH_SCHEME,URL_PATTERN) VALUES (?,?,?,?)";
+
+    private static String CROSS_TENANT_API_SUBSCRIPTIONS =
+            "SELECT AM_API.API_PROVIDER AS API_PROVIDER, AM_SUBSCRIBER.TENANT_ID AS SUBSCRIBER_TENANT_ID " +
+                    "FROM " +
+                    "AM_API, AM_SUBSCRIPTION, AM_APPLICATION, AM_SUBSCRIBER " +
+                    "WHERE " +
+                    "AM_SUBSCRIPTION.API_ID = AM_API.API_ID AND " +
+                    "AM_APPLICATION.APPLICATION_ID = AM_SUBSCRIPTION.APPLICATION_ID AND " +
+                    "AM_SUBSCRIBER.SUBSCRIBER_ID = AM_APPLICATION.SUBSCRIBER_ID";
 
     private APIMgtDAO() {
     }
@@ -466,5 +481,47 @@ public class APIMgtDAO {
         } catch (SQLException e) {
             throw new APIMigrationException("Error while adding URL template(s) to the database " + e);
         }
+    }
+
+    /**
+     * This method is used to check the existence of cross tenant subscriptions
+     *
+     * @param tenantManager Tenant Manager
+     * @return <code>true</code> if cross tenant subscriptions exist and
+     * <code>false</code> otherwise
+     * @throws APIMigrationException
+     */
+    public boolean isCrossTenantAPISubscriptionsExist(TenantManager tenantManager) throws APIMigrationException {
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            connection.setAutoCommit(false);
+            try (PreparedStatement preparedStatement = connection.prepareStatement(CROSS_TENANT_API_SUBSCRIPTIONS)) {
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    connection.commit();
+                    while (resultSet.next()) {
+                        int subscriberTenantId = resultSet.getInt("SUBSCRIBER_TENANT_ID");
+                        String apiProvider = resultSet.getString("API_PROVIDER");
+                        String apiProviderTenantDomain = MultitenantUtils.getTenantDomain(apiProvider);
+
+                        String subscriberTenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+                        for (Tenant tenant : tenantManager.getAllTenants()) {
+                            if (subscriberTenantId == tenant.getId()) {
+                                subscriberTenantDomain = tenant.getDomain();
+                                break;
+                            }
+                        }
+
+                        if (!subscriberTenantDomain.equals(apiProviderTenantDomain)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+        } catch (SQLException e) {
+            throw new APIMigrationException("SQLException when executing: ".concat(CROSS_TENANT_API_SUBSCRIPTIONS), e);
+        } catch (UserStoreException e) {
+            throw new APIMigrationException("Exception when retrieving tenants", e);
+        }
+        return false;
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -46,6 +46,7 @@ public class Constants {
     // Migration client argument property names
     public static final String ARG_RUN_SPECIFIC_VERSION = "runSpecificVersion";
     public static final String ARG_MIGRATE_FROM_VERSION = "migrateFromVersion";
+    public static final String ARG_IGNORE_CROSS_TENANT_SUBSCRIPTIONS = "ignoreCrossTenantSubscriptions";
     public static final String ARG_OPTIONS = "options";
     public static final String ARG_COMPONENT = "component";
     public static final String ARG_MIGRATE_TENANTS = "tenants";


### PR DESCRIPTION
Adding cross tenant subscription validation. With this the migrations to APIM 3.2 will be aborted if cross tenant subscriptions are found. 

To ignore the validation result and proceed with migration, set the flag `ignoreCrossTenantSubscriptions` to true as below
`sh wso2server.sh -DmigrateFromVersion=3.1.0 -DignoreCrossTenantSubscriptions=true`