### PR TITLE
Update migration client to add DefaultRoleCreation configuration to tenant-conf.json

### DIFF
--- a/migration-client/wso2-api-migration-client/buildNumber.properties
+++ b/migration-client/wso2-api-migration-client/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Thu Apr 16 16:29:04 IST 2020
-buildNumber=1
+#Mon Dec 07 17:54:39 IST 2020
+buildNumber=3


### PR DESCRIPTION
## Purpose
This PR updates migration client to add DefaultRoleCreation configuration to tenant-conf.json when migrating from 2.0.0
Fixes https://github.com/wso2/product-apim/issues/9603.