### PR TITLE
Update migration client to add DefaultRoleCreation configuration to tenant-conf.json

### DIFF
--- a/migration-client/wso2-api-migration-client/buildNumber.properties
+++ b/migration-client/wso2-api-migration-client/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Tue Dec 08 10:33:09 IST 2020
-buildNumber=2
+#Tue Dec 08 11:31:59 IST 2020
+buildNumber=4

--- a/migration-client/wso2-api-migration-client/buildNumber.properties
+++ b/migration-client/wso2-api-migration-client/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Thu Apr 16 16:29:04 IST 2020
-buildNumber=1
+#Tue Dec 08 10:33:09 IST 2020
+buildNumber=2

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
@@ -16,11 +16,18 @@
 
 package org.wso2.carbon.apimgt.migration.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.json.simple.JSONObject;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.sp_migration.APIMStatMigrationException;
 import org.wso2.carbon.apimgt.migration.util.RegistryService;
+import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
@@ -46,6 +53,7 @@ public class MigrateFrom200 extends MigrationClientBase implements MigrationClie
     public void registryResourceMigration() throws APIMigrationException {
         updateGenericAPIArtifacts(registryService);
         migrateFaultSequencesInRegistry(registryService);
+        addDefaultRoleCreationConfig();
     }
 
     @Override
@@ -77,5 +85,52 @@ public class MigrateFrom200 extends MigrationClientBase implements MigrationClie
 
     @Override
     public void populateScopeRoleMapping() throws APIMigrationException {
+    }
+
+    public void addDefaultRoleCreationConfig() throws APIMigrationException {
+
+        log.info("Add config in tenant-conf.json to enable default roles creation.");
+        for (Tenant tenant : getTenantsArray()) {
+            try {
+                registryService.startTenantFlow(tenant);
+                log.info("Updating tenant-conf.json of tenant " + tenant.getId() + '(' +
+                        tenant.getDomain() + ')');
+                // Retrieve the tenant-conf.json of the corresponding tenant
+                JSONObject tenantConf = APIUtil.getTenantConfig(tenant.getDomain());
+                if (tenantConf.get(APIConstants.API_TENANT_CONF_DEFAULT_ROLES) == null) {
+                    JSONObject defaultRoleConfig = new JSONObject();
+                    JSONObject publisherRole = new JSONObject();
+                    publisherRole.put("CreateOnTenantLoad", true);
+                    publisherRole.put("RoleName", "Internal/publisher");
+
+                    JSONObject creatorRole = new JSONObject();
+                    creatorRole.put("CreateOnTenantLoad", true);
+                    creatorRole.put("RoleName", "Internal/creator");
+
+                    JSONObject subscriberRole = new JSONObject();
+                    subscriberRole.put("CreateOnTenantLoad", true);
+
+                    defaultRoleConfig.put("PublisherRole", publisherRole);
+                    defaultRoleConfig.put("CreatorRole", creatorRole);
+                    defaultRoleConfig.put("SubscriberRole", subscriberRole);
+                    tenantConf.put("DefaultRoles", defaultRoleConfig);
+                    ObjectMapper mapper = new ObjectMapper();
+                    String formattedTenantConf = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tenantConf);
+
+                    APIUtil.updateTenantConf(formattedTenantConf, tenant.getDomain());
+                    log.info("Updated tenant-conf.json for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')'
+                            + "\n" + formattedTenantConf);
+
+                    log.info("End updating tenant-conf.json to add default role creation configuration for tenant "
+                            + tenant.getId() + '(' + tenant.getDomain() + ')');
+                }
+            } catch (APIManagementException e) {
+                log.error("Error while retrieving the tenant-conf.json of tenant " + tenant.getId(), e);
+            } catch (JsonProcessingException e) {
+                log.error("Error while formatting tenant-conf.json of tenant " + tenant.getId(), e);
+            } finally {
+                registryService.endTenantFlow();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Purpose
This PR updates migration client to add DefaultRoleCreation configuration to tenant-conf.json when migrating from 2.0.0
Fixes https://github.com/wso2/product-apim/issues/9603.