### PR TITLE
Fix apiCreatorTenantDomain returning a partial value in Analytics Migration

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/DBManagerImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/DBManagerImpl.java
@@ -247,7 +247,7 @@ public class DBManagerImpl implements DBManager {
                     //Get apiCreatorTenantDomain from Context
                     if (context.contains(TENANT_DOMAIN_IDENTIFIER)) {
                         apiCreatorTenantDomain = apiPublisher.substring(apiPublisher.lastIndexOf(AT_IDENTIFIER) + 1,
-                                apiPublisher.length() - 1);
+                                apiPublisher.length());
                     } else {
                         apiCreatorTenantDomain = SUPER_TENANT_DOMAIN;
                     }


### PR DESCRIPTION
## Purpose
With the current approach the value of 'apiCreatorTenantDomain' under migrateResourceUsageSummaryTable will give a value with a missing character.

Fixes #67 