### PR TITLE
[3.2.0] Fixing the check done to see if the overview type is null

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -426,7 +426,7 @@ public class RegistryServiceImpl implements RegistryService {
                 artifact.setAttribute(Constants.API_OVERVIEW_TYPE, overview_type);
                 isResourceUpdated = true;
             }
-            if (overview_type == null || overview_type.trim().isEmpty()){
+            if (overview_type.trim().isEmpty() || "NULL".equalsIgnoreCase(overview_type))  {
                 if (log.isDebugEnabled()) {
                     log.debug("API at " + resourcePath + "did not have property : " + Constants.API_OVERVIEW_TYPE
                             + ", hence adding the default value - HTTP for that API resource.");

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -426,7 +426,7 @@ public class RegistryServiceImpl implements RegistryService {
                 artifact.setAttribute(Constants.API_OVERVIEW_TYPE, overview_type);
                 isResourceUpdated = true;
             }
-            if (overview_type.trim().isEmpty() || "NULL".equalsIgnoreCase(overview_type))  {
+            if (overview_type == null || overview_type.trim().isEmpty() || "NULL".equalsIgnoreCase(overview_type)) {
                 if (log.isDebugEnabled()) {
                     log.debug("API at " + resourcePath + "did not have property : " + Constants.API_OVERVIEW_TYPE
                             + ", hence adding the default value - HTTP for that API resource.");


### PR DESCRIPTION
## Purpose
Fixes the migration problem to APIM 3.2.0 by fixing the checking done to see if the overview type is null.

## Goals
Cherry-pick the commits of [1].

[1] https://github.com/wso2-extensions/apim-migration-resources/pull/69