### PR TITLE
Label - Vhost migration for APIM 2.5, 2.6, 3.0, 3.1

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -156,6 +156,9 @@ public class APIMMigrationService implements ServerStartupObserver {
                 identityScopeMigration.migrateScopes();
                 MigrateFrom320 migrateFrom320 = new MigrateFrom320(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
+                if (V250.equals(migrateFromVersion) || V260.equals(migrateFromVersion)) {
+                    migrateFrom320.migrateLabelsToVhosts();
+                }
                 migrateFrom320.migrateProductMappingTable();
                 migrateFrom320.updateRegistryPathsOfIconAndWSDL();
                 migrateFrom320.apiRevisionRelatedMigration();
@@ -179,6 +182,7 @@ public class APIMMigrationService implements ServerStartupObserver {
                 identityScopeMigration.migrateScopes();
                 MigrateFrom320 migrateFrom320 = new MigrateFrom320(tenants, blackListTenants,
                         tenantRange, registryService, tenantManager);
+                migrateFrom320.migrateLabelsToVhosts();
                 migrateFrom320.migrateProductMappingTable();
                 migrateFrom320.updateRegistryPathsOfIconAndWSDL();
                 migrateFrom320.apiRevisionRelatedMigration();

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -438,8 +438,9 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
 
                 List<VHost> vhosts = new ArrayList<>(labelDTO.getAccessUrls().size());
                 for (String accessUrl : labelDTO.getAccessUrls()) {
-                    // Hope to move 'fromEndpointUrls' function to another class, changing carbon version may
-                    // need to change this class
+                    if (!StringUtils.contains(accessUrl, VHost.PROTOCOL_SEPARATOR)) {
+                        accessUrl = VHost.HTTPS_PROTOCOL + VHost.PROTOCOL_SEPARATOR + accessUrl;
+                    }
                     VHost vhost = VHost.fromEndpointUrls(new String[]{accessUrl});
                     vhosts.add(vhost);
                 }


### PR DESCRIPTION
## Purpose
- Do migrations for All other versions (APIM 2.5, 2.6, 3.0, 3.1)
- Append protocol if labels access URL does not contain the protocol (in APIM versions other than 3.2.0 is not validating the label's access URL, the user could be given the full access URL [i.e. https://mg.wso2.com] or just host only [i.e. mg.wso2.com])

Tested with APIM 2.5 to APIM 4.0 migration

## Related Issues
https://github.com/wso2/product-apim/issues/10151
