### PR TITLE
Remove Unnecessary Fault Handlers from Fault Sequences when Migrating to APIM 4.0.0

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -308,6 +308,10 @@ public class APIMMigrationService implements ServerStartupObserver {
                 migrateFrom320.updateRegistryPathsOfIconAndWSDL();
                 log.info("Successfully migrated API registry paths of Icon and WSDLs.");
 
+                log.info("Start removing unnecessary fault handlers from fault sequences ..........");
+                migrateFrom320.removeUnnecessaryFaultHandlers();
+                log.info("Successfully removed the unnecessary fault handlers from fault sequences.");
+
                 log.info("Start API Revision related migration ..........");
                 migrateFrom320.apiRevisionRelatedMigration();
                 log.info("Successfully done the API Revision related migration.");

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -156,6 +156,10 @@ public class APIMMigrationService implements ServerStartupObserver {
                 migrateFrom320.updateRegistryPathsOfIconAndWSDL();
                 log.info("Successfully migrated API registry paths of Icon and WSDLs.");
 
+                log.info("Start removing unnecessary fault handlers from fault sequences ..........");
+                migrateFrom320.removeUnnecessaryFaultHandlers();
+                log.info("Successfully removed the unnecessary fault handlers from fault sequences.");
+
                 log.info("Start API Revision related migration ..........");
                 migrateFrom320.apiRevisionRelatedMigration();
                 log.info("API Revision related migration is successful.");
@@ -228,6 +232,10 @@ public class APIMMigrationService implements ServerStartupObserver {
                 migrateFrom320.updateRegistryPathsOfIconAndWSDL();
                 log.info("Successfully migrated API registry paths of Icon and WSDLs.");
 
+                log.info("Start removing unnecessary fault handlers from fault sequences ..........");
+                migrateFrom320.removeUnnecessaryFaultHandlers();
+                log.info("Successfully removed the unnecessary fault handlers from fault sequences.");
+
                 log.info("Start API Revision related migration ..........");
                 migrateFrom320.apiRevisionRelatedMigration();
                 log.info("API Revision related migration is successful.");
@@ -276,6 +284,10 @@ public class APIMMigrationService implements ServerStartupObserver {
                 log.info("Start migrating registry paths of Icon and WSDLs  ..........");
                 migrateFrom320.updateRegistryPathsOfIconAndWSDL();
                 log.info("Successfully migrated API registry paths of Icon and WSDLs.");
+
+                log.info("Start removing unnecessary fault handlers from fault sequences ..........");
+                migrateFrom320.removeUnnecessaryFaultHandlers();
+                log.info("Successfully removed the unnecessary fault handlers from fault sequences.");
 
                 log.info("Start API Revision related migration ..........");
                 migrateFrom320.apiRevisionRelatedMigration();

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -73,6 +73,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.security.KeyStore;

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -573,19 +573,19 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                 PrivilegedCarbonContext.endTenantFlow();
             }
         } catch (RegistryException e) {
-            log.error("Error while intitiation the registry", e);
+            log.error("Error while initiating the registry", e);
         } catch (UserStoreException e) {
             log.error("Error while retrieving the tenants", e);
         } catch (APIManagementException e) {
-            log.error("Error while Retrieving API artifact from the registry", e);
+            log.error("Error while retrieving tenant admin's username", e);
         } catch (org.wso2.carbon.registry.api.RegistryException e) {
-            e.printStackTrace();
+            log.error("Error while retrieving fault sequences", e);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error while removing unnecessary fault handlers from fault sequences", e);
         }
     }
 
-    private static String toString(Document newDoc) throws Exception{
+    private static String toString(Document newDoc) throws Exception {
         DOMSource domSource = new DOMSource(newDoc);
         Transformer transformer = TransformerFactory.newInstance().newTransformer();
         StringWriter sw = new StringWriter();

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -527,14 +527,16 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                 APIUtil.loadTenantRegistry(apiTenantId);
                 startTenantFlow(tenant.getDomain(), apiTenantId,
                         MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
-                this.registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(apiTenantId);
+                this.registry = ServiceReferenceHolder.getInstance().getRegistryService()
+                        .getGovernanceSystemRegistry(apiTenantId);
                 // Fault Handlers that needs to be removed from fault sequences
                 String unnecessaryFaultHandler1 = "org.wso2.carbon.apimgt.usage.publisher.APIMgtFaultHandler";
                 String unnecessaryFaultHandler2 = "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtFaultHandler";
                 org.wso2.carbon.registry.api.Collection seqCollection;
                 seqCollection = (org.wso2.carbon.registry.api.Collection) registry
-                        .get(org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_LOCATION + RegistryConstants.PATH_SEPARATOR +
-                                org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT);
+                        .get(org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_LOCATION
+                                + RegistryConstants.PATH_SEPARATOR
+                                + org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT);
                 if (seqCollection != null) {
                     String[] childPaths = seqCollection.getChildren();
                     for (String childPath : childPaths) {
@@ -556,8 +558,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                 namedItem = attr.getNamedItem("name");
                             }
                             // Remove the relevant fault handlers
-                            if (unnecessaryFaultHandler1.equals(namedItem.getNodeValue()) || 
-                                    unnecessaryFaultHandler2.equals(namedItem.getNodeValue())) {
+                            if (unnecessaryFaultHandler1.equals(namedItem.getNodeValue()) || unnecessaryFaultHandler2
+                                    .equals(namedItem.getNodeValue())) {
                                 Node parentNode = node.getParentNode();
                                 parentNode.removeChild(node);
                                 parentNode.normalize();


### PR DESCRIPTION
## Purpose
Remove the following fault handlers from fault sequences when migrating to APIM 4.0.0
1. org.wso2.carbon.apimgt.usage.publisher.APIMgtFaultHandler
2. org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtFaultHandler

Fixes: https://github.com/wso2/product-apim/issues/10238

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/10136
