### PR TITLE
[3.2.0] Update migration client to support IP based block conditions when migrating from 2.x versions to 3.2.0

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -140,6 +140,8 @@ public class APIMMigrationService implements ServerStartupObserver {
                 log.info("Populating WSO2 API Manager Scope-Role Mapping");
                 scopeRoleMappingPopulation.updateScopeRoleMappings();
                 scopeRoleMappingPopulation.populateScopeRoleMapping();
+                log.info("Migrating WSO2 API Manager IP based block conditions");
+                migrateFrom210.updateIpBasedBlockingConditions();
                 log.info("Migrated Successfully to API Manager 3.1");
                 log.info("Starting Migration from API Manager 3.1 to 3.2");
                 MigrationClient migrateFrom310 = new MigrateFrom310(tenants, blackListTenants,

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom110to200.java
@@ -128,6 +128,10 @@ public class MigrateFrom110to200 extends MigrationClientBase implements Migratio
     }
 
     @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
+    @Override
     public void statsMigration() throws APIMigrationException {
         log.info("Stat Database migration for API Manager started");
         String statScriptPath = CarbonUtils.getCarbonHome() + File.separator + "migration-scripts" + File.separator +

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom18to19.java
@@ -1276,6 +1276,10 @@ public class MigrateFrom18to19 extends MigrationClientBase implements MigrationC
     public void updateScopeRoleMappings() throws APIMigrationException {
     }
 
+    @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
     /**
      * This method will be used to populate SP_APP table
      */

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom19to110.java
@@ -852,6 +852,10 @@ public class MigrateFrom19to110 extends MigrationClientBase implements Migration
     }
 
     @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
+    @Override
     public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
             throws APIMigrationException {
     }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200.java
@@ -101,6 +101,10 @@ public class MigrateFrom200 extends MigrationClientBase implements MigrationClie
     }
 
     @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
+    @Override
     public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
             throws APIMigrationException {
     }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom200to210.java
@@ -93,6 +93,10 @@ public class MigrateFrom200to210 extends MigrationClientBase implements Migratio
     public void updateScopeRoleMappings() throws APIMigrationException {
     }
 
+    @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
     private void migrateFaultSequencesInRegistry() {
 
         /* change the APIMgtFaultHandler class name in debug_json_fault.xml and json_fault.xml

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom210.java
@@ -18,18 +18,14 @@ package org.wso2.carbon.apimgt.migration.client;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.model.BlockConditionsDTO;
 import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.sp_migration.APIMStatMigrationException;
+import org.wso2.carbon.apimgt.migration.dao.APIMgtDAO;
 import org.wso2.carbon.apimgt.migration.util.RegistryService;
-import org.wso2.carbon.registry.core.exceptions.RegistryException;
-import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.tenant.TenantManager;
-import org.wso2.carbon.utils.CarbonUtils;
-import org.wso2.carbon.utils.FileUtil;
 
-import java.io.File;
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -95,6 +91,26 @@ public class MigrateFrom210 extends MigrationClientBase implements MigrationClie
 
     @Override
     public void updateScopeRoleMappings() throws APIMigrationException {
+    }
+
+    @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+
+        APIMgtDAO apiMgtDAO = APIMgtDAO.getInstance();
+        List<BlockConditionsDTO> blockConditionsDTOs = apiMgtDAO.getBlockConditions();
+
+        // Change values of the Ip based block conditions
+        for(BlockConditionsDTO blockCondition : blockConditionsDTOs) {
+            if (blockCondition.getConditionType().equals("IP")){
+                String value = blockCondition.getConditionValue();
+                String [] splits  = value.split(":");
+                String jsonString = "{" +"\"invert\":false,\"fixedIp\":\"" + splits[1] + "\"}";
+                blockCondition.setConditionValue(jsonString);
+            }
+        }
+
+        // Update block conditions
+        apiMgtDAO.updateIpBasedBlockConditionsValue(blockConditionsDTOs);
     }
 
     @Override

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
@@ -116,6 +116,10 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
     }
 
     @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
+    @Override
     public void scopeMigration() throws APIMigrationException {
         APIMgtDAO apiMgtDAO = APIMgtDAO.getInstance();
         // Step 1: remove duplicate entries

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClient.java
@@ -120,6 +120,13 @@ public interface MigrationClient {
     void updateScopeRoleMappings() throws APIMigrationException;
 
     /**
+     * This method is used to update ip based deny policies/blocking conditions during 2.x to 3.2 migrations
+     *
+     * @throws APIMigrationException
+     */
+    void updateIpBasedBlockingConditions() throws APIMigrationException;
+
+    /**
      * This method is used to check the existence of cross tenant subscriptions
      * during the migrations to 3.2
      *

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ScopeRoleMappingPopulationClient.java
@@ -181,6 +181,10 @@ public class ScopeRoleMappingPopulationClient extends MigrationClientBase implem
     }
 
     @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
+    @Override
     public void scopeMigration() throws APIMigrationException {
     }
 

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/sp_migration/APIMStatMigrationClient.java
@@ -192,6 +192,10 @@ public class APIMStatMigrationClient extends MigrationClientBase implements Migr
     }
 
     @Override
+    public void updateIpBasedBlockingConditions() throws APIMigrationException {
+    }
+
+    @Override
     public void checkCrossTenantAPISubscriptions(TenantManager tenantManager, boolean ignoreCrossTenantSubscriptions)
             throws APIMigrationException {
     }


### PR DESCRIPTION

## Purpose
The block conditions on 2.x versions are stored as follows.
![ScreenShot Tool -20210816163111](https://user-images.githubusercontent.com/42435576/129704596-a2f3d62c-26ce-46ca-a14d-d5a58abd7899.png)

The block conditions on 3.2.0 versions are stored as follows.
![ScreenShot Tool -20210816163752](https://user-images.githubusercontent.com/42435576/129704501-bbb58c54-6ec6-4540-9301-16ea6af29153.png)

When migration occurs the VALUE of these tables gives an issue. This PR will fix that issue to edit the values of the VALUE column of 2.x versions into JSON format.
