### PR TITLE
Add the app owner rewrite option when migrating from 2.x to 3.2.0

### DIFF
--- a/migration-client/wso2-api-migration-client/buildNumber.properties
+++ b/migration-client/wso2-api-migration-client/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Thu Oct 14 12:44:31 IST 2021
+#Thu Oct 14 18:26:56 IST 2021
 buildNumber=5

--- a/migration-client/wso2-api-migration-client/buildNumber.properties
+++ b/migration-client/wso2-api-migration-client/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Thu Oct 14 18:26:56 IST 2021
-buildNumber=5
+#Tue Oct 19 16:20:43 IST 2021
+buildNumber=6

--- a/migration-client/wso2-api-migration-client/buildNumber.properties
+++ b/migration-client/wso2-api-migration-client/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Wed May 12 15:46:40 IST 2021
-buildNumber=4
+#Thu Oct 14 12:44:31 IST 2021
+buildNumber=5

--- a/migration-client/wso2-api-migration-client/pom.xml
+++ b/migration-client/wso2-api-migration-client/pom.xml
@@ -188,6 +188,11 @@
             <version>${carbon.apimgt.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.8.5</version>
@@ -206,5 +211,6 @@
         <carbon.governance.version>4.8.14</carbon.governance.version>
         <carbon.kernel.version>4.4.40</carbon.kernel.version>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+        <carbon.identity.framework.version>5.17.5</carbon.identity.framework.version>
     </properties>
 </project>

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.apimgt.migration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
+import org.wso2.carbon.apimgt.migration.client.ApplicationOwnerChangeManagementClient;
 import org.wso2.carbon.apimgt.migration.client.MigrateFrom200;
 import org.wso2.carbon.apimgt.migration.client.MigrateFrom210;
 import org.wso2.carbon.apimgt.migration.client.MigrateFrom310;
@@ -89,6 +90,7 @@ public class APIMMigrationService implements ServerStartupObserver {
         boolean ignoreCrossTenantSubscriptions =
                 Boolean.parseBoolean(System.getProperty(Constants.ARG_IGNORE_CROSS_TENANT_SUBSCRIPTIONS));
         boolean isSPAppAssignment = Boolean.parseBoolean(System.getProperty(Constants.ARG_ASSIGN_OAUTH_APPS_TO_OWNERS));
+        boolean isAppNameRewrite = Boolean.parseBoolean(System.getProperty(Constants.APP_NAME_REWRITE));
 
         try {
             RegistryServiceImpl registryService = new RegistryServiceImpl();
@@ -97,6 +99,14 @@ public class APIMMigrationService implements ServerStartupObserver {
                 OauthAppAssignmentClient oauthAppAssignMentClient = new OauthAppAssignmentClient(tenants,
                         blackListTenants, tenantRange, tenantManager);
                 oauthAppAssignMentClient.assignOauthAppToOwners();
+            }
+
+            if (isAppNameRewrite) {
+                log.info("----------------App Name rewrite for owner changed applications started------------------");
+                ApplicationOwnerChangeManagementClient ownerChangeManagementClient =
+                        new ApplicationOwnerChangeManagementClient(tenants, blackListTenants, tenantRange,
+                        tenantManager);
+                ownerChangeManagementClient.updateApplicationOwner();
             }
             //Check SP-Migration enabled
             if (isSPMigration) {

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/APIMMigrationService.java
@@ -90,7 +90,8 @@ public class APIMMigrationService implements ServerStartupObserver {
         boolean ignoreCrossTenantSubscriptions =
                 Boolean.parseBoolean(System.getProperty(Constants.ARG_IGNORE_CROSS_TENANT_SUBSCRIPTIONS));
         boolean isSPAppAssignment = Boolean.parseBoolean(System.getProperty(Constants.ARG_ASSIGN_OAUTH_APPS_TO_OWNERS));
-        boolean isAppNameRewrite = Boolean.parseBoolean(System.getProperty(Constants.APP_NAME_REWRITE));
+        boolean overrideSPAppName = Boolean.parseBoolean(System.getProperty(Constants.OVERRIDE_APP_NAME));
+        boolean isEvaluateSPAppName = Boolean.parseBoolean(System.getProperty(Constants.EVALUATE_SP_APP_NAME)) || overrideSPAppName;
 
         try {
             RegistryServiceImpl registryService = new RegistryServiceImpl();
@@ -101,12 +102,12 @@ public class APIMMigrationService implements ServerStartupObserver {
                 oauthAppAssignMentClient.assignOauthAppToOwners();
             }
 
-            if (isAppNameRewrite) {
-                log.info("----------------App Name rewrite for owner changed applications started------------------");
+            if (isEvaluateSPAppName) {
+                log.info("----------------SP App Name rewrite for owner changed applications started------------------");
                 ApplicationOwnerChangeManagementClient ownerChangeManagementClient =
                         new ApplicationOwnerChangeManagementClient(tenants, blackListTenants, tenantRange,
                         tenantManager);
-                ownerChangeManagementClient.updateApplicationOwner();
+                ownerChangeManagementClient.updateApplicationOwner(overrideSPAppName);
             }
             //Check SP-Migration enabled
             if (isSPMigration) {

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ApplicationOwnerChangeManagementClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ApplicationOwnerChangeManagementClient.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.apimgt.migration.client;
 import com.google.gson.Gson;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.internal.ServiceHolder;
 import org.wso2.carbon.apimgt.migration.dao.APIMgtDAO;
@@ -74,7 +75,7 @@ public class ApplicationOwnerChangeManagementClient extends MigrationClientBase 
                                 .getTenantAwareUsername(appDetailsDTO.getAppSubscriber()));
                         if (existingUser) {
                             String currentSPAppName = appDetailsDTO.getCurrentSPAppName();
-                            String qualifiedSPName = appDetailsDTO.getUserName() + "_" + appDetailsDTO.getAppName() +
+                            String qualifiedSPName = APIUtil.replaceEmailDomain(appDetailsDTO.getUserName()) + "_" + appDetailsDTO.getAppName() +
                                     "_" + appDetailsDTO.getKeyType();
                             if (!qualifiedSPName.equals(currentSPAppName)) {
                                 log.info("Current SP name " + currentSPAppName

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ApplicationOwnerChangeManagementClient.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/ApplicationOwnerChangeManagementClient.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.client;
+
+import com.google.gson.Gson;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
+import org.wso2.carbon.apimgt.migration.client.internal.ServiceHolder;
+import org.wso2.carbon.apimgt.migration.dao.APIMgtDAO;
+import org.wso2.carbon.apimgt.migration.dto.ApplicationDetailsDTO;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.List;
+
+/**
+ * This Class is used to update the SP APP name, Role Name, and IDN Application name if the owner of the Application is transferred
+ * From APIM 3.2.0, when we transfer the owner of an application, SP Name, Role Name changes with the transferred user.
+ * Eg: If the Application name is PizzaApp created by user chris, SP app name would be chris_PizzaApp_Production and the role
+ * associated with that app would be Application/chris_PizzaApp_Production. Once we transfer this to kim user, before 3.x,
+ * owner transfer happens, but we don not update the created application names or role names. From 3.2.0 onwards, we update
+ * these such that SP app would be changed to kim_PizzaApp_Production and role to Application/kim_PizzaApp_Production.
+ *
+ * With this class, we will query the tables and regenerate the expected SP APP name. If that name differs with the current
+ * SP app name, tool will update the Service Provider with the expected name.
+ */
+public class ApplicationOwnerChangeManagementClient extends MigrationClientBase {
+
+    private static final Log log = LogFactory.getLog(ApplicationOwnerChangeManagementClient.class);
+
+    APIMgtDAO apiMgtDAO = APIMgtDAO.getInstance();
+    ApplicationManagementService applicationManagementService = ServiceHolder.getApplicationManagementService();
+
+    public ApplicationOwnerChangeManagementClient(String tenantArguments, String blackListTenantArguments,
+                                                  String tenantRange,
+                                                  TenantManager tenantManager) throws UserStoreException {
+
+        super(tenantArguments, blackListTenantArguments, tenantRange, tenantManager);
+    }
+
+    public void updateApplicationOwner() throws APIMigrationException {
+
+        for (Tenant tenant : getTenantsArray()) {
+            List<ApplicationDetailsDTO> appDetailDTOList = apiMgtDAO.retrieveApplicationInfoForTenant(tenant);
+            for (ApplicationDetailsDTO appDetailsDTO : appDetailDTOList) {
+                if (appDetailsDTO.getAppSubscriber().equals(appDetailsDTO.getCreatedBy())
+                        && MultitenantUtils
+                        .getTenantAwareUsername(appDetailsDTO.getCreatedBy()).equals(appDetailsDTO.getUserName())) {
+                    try {
+                        UserStoreManager userStoreManager = ServiceHolder.getRealmService()
+                                .getTenantUserRealm(tenant.getId()).getUserStoreManager();
+                        boolean existingUser = userStoreManager.isExistingUser(MultitenantUtils
+                                .getTenantAwareUsername(appDetailsDTO.getAppSubscriber()));
+                        if (existingUser) {
+                            String currentSPAppName = appDetailsDTO.getCurrentSPAppName();
+                            String qualifiedSPName = appDetailsDTO.getUserName() + "_" + appDetailsDTO.getAppName() +
+                                    "_" + appDetailsDTO.getKeyType();
+                            if (!qualifiedSPName.equals(currentSPAppName)) {
+                                log.info("Current SP name " + currentSPAppName
+                                        + " does not match with expected SP name of " + qualifiedSPName);
+                                ServiceProvider serviceProvider = applicationManagementService
+                                        .getServiceProvider(currentSPAppName, tenant.getDomain());
+                                if (serviceProvider != null) {
+                                    ServiceProvider clonedSP = cloneServiceProvider(serviceProvider);
+                                    clonedSP.setApplicationName(qualifiedSPName);
+                                    try {
+                                        applicationManagementService.updateApplication(clonedSP, tenant.getDomain(),
+                                                appDetailsDTO.getCreatedBy());
+                                        log.info("SP name updated for " + currentSPAppName
+                                                + " with " + qualifiedSPName);
+                                    } catch (Exception e) {
+                                        log.error("Error updating the SP " + currentSPAppName + " in tenant " +
+                                                tenant.getDomain(), e);
+                                    }
+                                } else {
+                                    log.error("Valid SP not found for " + currentSPAppName + " in tenant " +
+                                            tenant.getDomain());
+                                }
+                            }
+                        } else {
+                            log.error("User " + MultitenantUtils
+                                    .getTenantAwareUsername(appDetailsDTO.getAppSubscriber()) + " from tenant domain "
+                                    + tenant.getDomain() + " does not exists");
+                        }
+                    } catch (IdentityApplicationManagementException | UserStoreException e) {
+                        log.error("Error retrieving the SP for App" + appDetailsDTO.getAppName() + " in tenant " +
+                                tenant.getDomain(), e);
+                    }
+                } else {
+                    log.info("User from IDN table: " + appDetailsDTO.getUserName() + " user from SUB table: " +
+                            appDetailsDTO.getAppSubscriber()
+                            + " user from APP table: " + appDetailsDTO.getCreatedBy());
+                    log.error(
+                            "User details does not match. Hence skipped the application " + appDetailsDTO.getAppName());
+                }
+            }
+        }
+    }
+
+    /**
+     * Create a deep copy of the input Service Provider.
+     *
+     * @param serviceProvider Service Provider.
+     * @return Clone of serviceProvider.
+     */
+    public static ServiceProvider cloneServiceProvider(ServiceProvider serviceProvider) {
+
+        Gson gson = new Gson();
+        ServiceProvider clonedServiceProvider = gson.fromJson(gson.toJson(serviceProvider), ServiceProvider.class);
+        return clonedServiceProvider;
+    }
+
+}

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dto/ApplicationDetailsDTO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dto/ApplicationDetailsDTO.java
@@ -1,0 +1,92 @@
+package org.wso2.carbon.apimgt.migration.dto;
+
+public class ApplicationDetailsDTO {
+    String appName;
+    String currentSPAppName;
+    String appSubscriber;
+    String consumerKey;
+    String keyType;
+    String createdBy;
+    String userDomain;
+    String userName;
+
+    public String getAppName() {
+
+        return appName;
+    }
+
+    public void setAppName(String appName) {
+
+        this.appName = appName;
+    }
+
+    public String getAppSubscriber() {
+
+        return appSubscriber;
+    }
+
+    public void setAppSubscriber(String appSubscriber) {
+
+        this.appSubscriber = appSubscriber;
+    }
+
+    public String getConsumerKey() {
+
+        return consumerKey;
+    }
+
+    public void setConsumerKey(String consumerKey) {
+
+        this.consumerKey = consumerKey;
+    }
+
+    public String getCreatedBy() {
+
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+
+        this.createdBy = createdBy;
+    }
+
+    public String getKeyType() {
+
+        return keyType;
+    }
+
+    public void setKeyType(String keyType) {
+
+        this.keyType = keyType;
+    }
+
+    public String getCurrentSPAppName() {
+
+        return currentSPAppName;
+    }
+
+    public void setCurrentSPAppName(String currentSPAppName) {
+
+        this.currentSPAppName = currentSPAppName;
+    }
+
+    public String getUserDomain() {
+
+        return userDomain;
+    }
+
+    public void setUserDomain(String userDomain) {
+
+        this.userDomain = userDomain;
+    }
+
+    public String getUserName() {
+
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+
+        this.userName = userName;
+    }
+}

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -349,4 +349,5 @@ public class Constants {
     public static final String NAME = "Name";
     public static final String ROLES = "Roles";
     public static final String ARG_ASSIGN_OAUTH_APPS_TO_OWNERS = "assignOauthAppOwners";
+    public static final String APP_NAME_REWRITE = "appNameRewrite";
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -349,5 +349,6 @@ public class Constants {
     public static final String NAME = "Name";
     public static final String ROLES = "Roles";
     public static final String ARG_ASSIGN_OAUTH_APPS_TO_OWNERS = "assignOauthAppOwners";
-    public static final String APP_NAME_REWRITE = "appNameRewrite";
+    public static final String EVALUATE_SP_APP_NAME = "evaluateSPAppName";
+    public static final String OVERRIDE_APP_NAME = "overrideSPAppName";
 }


### PR DESCRIPTION
## Purpose
 This option is used to update the SP APP name, Role Name, and IDN Application name if the owner of the Application is transferred. 
From APIM 3.2.0, when we transfer the ownership of an application, SP Name, Role Name changes with the transferred user. Eg: If the Application name is PizzaApp created by user chris, SP app name would be chris_PizzaApp_Production and the role associated with that app would be Application/chris_PizzaApp_Production. 

Once we transfer this to kim user, before 3.x, owner transfer happens, but we don not update the created application names or role names. 
From 3.2.0 onwards, we update these such that SP app would be changed to kim_PizzaApp_Production and role to Application/kim_PizzaApp_Production.
 
 With this flow, we will query the tables and regenerate the expected SP APP name. If that name differs from the current
SP app name, tool will update the Service Provider with the expected name.

To use this flow, use the environment variable ```wso2server.sh -DappNameRewrite=true```