### PR TITLE
Resolve concurrent modification exception in resource map

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/RegistryServiceImpl.java
@@ -52,6 +52,8 @@ import org.wso2.carbon.user.api.UserStoreException;
 import javax.xml.stream.XMLStreamException;
 import java.io.FileNotFoundException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 
@@ -497,19 +499,23 @@ public class RegistryServiceImpl implements RegistryService {
                 log.debug("Updating properties for registry path: " + resourcePath);
             }
             Properties map = resource.getProperties();
+            List<String> modifiableKeys= new ArrayList<>();
             for (Object entry : map.keySet()) {
                 String key = entry.toString();
                 if (key.startsWith("api_meta.") && !key.endsWith("__display")) {
-                    String newKey = key + "__display";
-                    if (log.isDebugEnabled()) {
-                        log.debug("Replacing property: " + key + " with property: " + newKey);
-                    }
-                    resource.addProperty(newKey, resource.getProperty(key));
-                    resource.removeProperty(key);
+                    modifiableKeys.add(key);
                     isResourceUpdated = true;
                 }
             }
             if (isResourceUpdated) {
+                for (String modifiableKey : modifiableKeys) {
+                    String newKey = modifiableKey + "__display";
+                    if (log.isDebugEnabled()) {
+                        log.debug("Replacing property: " + modifiableKey + " with property: " + newKey);
+                    }
+                    resource.addProperty(newKey, resource.getProperty(modifiableKey));
+                    resource.removeProperty(modifiableKey);
+                }
                 registry.put(resourcePath, resource);
             }
         } catch (UserStoreException | RegistryException e) {


### PR DESCRIPTION
### Purpose

$Subject

### User Story

Properties added without the display in the developer portal before migration are visible in-store after migration. 

![Screenshot from 2021-11-03 14-21-30](https://user-images.githubusercontent.com/60866295/140031693-ccf6e302-f77c-4d67-9dce-b5cd9b0a5ef9.png)


