### PR TITLE
[4.1.0 - Migration] Add identity scope migrator for 3.1.0 to 3.2.0 migration

### DIFF
--- a/components/migration-client/wso2-api-migration-client/pom.xml
+++ b/components/migration-client/wso2-api-migration-client/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.persistence</artifactId>
-            <version>9.20.74</version>
+            <version>${carbon.apimgt.version}</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.common</artifactId>
-            <version>9.20.74</version>
+            <version>${carbon.apimgt.version}</version>
         </dependency>
 
     </dependencies>

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/client/V320Migration.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/client/V320Migration.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.migrator.VersionMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.commonMigrators.PreDBScriptMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.commonMigrators.RegistryResourceMigrator;
+import org.wso2.carbon.apimgt.migration.migrator.v320.IdentityScopeMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.v320.SPMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.v320.ScopeMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.v320.V320RegistryResourceMigrator;
@@ -52,7 +53,9 @@ public class V320Migration extends VersionMigrator {
         scopeMigrator.migrate();
         SPMigrator spMigrator = new SPMigrator();
         spMigrator.migrate();
-        log.info("Starting migration from " + getPreviousVersion() + " to " + getCurrentVersion() + "...");
+        IdentityScopeMigrator identityScopeMigrator = new IdentityScopeMigrator();
+        identityScopeMigrator.migrate();
+        log.info("Completed migration from " + getPreviousVersion() + " to " + getCurrentVersion() + "...");
     }
 
 

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v320/IdentityScopeMigrator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v320/IdentityScopeMigrator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.migrator.v320;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.impl.dao.ScopesDAO;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
+import org.wso2.carbon.apimgt.migration.migrator.Migrator;
+import org.wso2.carbon.apimgt.migration.migrator.v320.dao.ApiMgtDAO;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class is used to migrate scopes from IDN_OAUTH2_SCOPE table to AM_SCOPE table during 3.1.0 to 3.2.0 migration
+ */
+public class IdentityScopeMigrator extends Migrator {
+
+    private static final Log log = LogFactory.getLog(IdentityScopeMigrator.class);
+
+    @Override
+    public void migrate() throws APIMigrationException {
+        log.info("Starting identity scope migration...");
+        boolean scopesMigrated = ApiMgtDAO.getInstance().isScopesMigrated();
+        if (!scopesMigrated) {
+            List<String> identityScopes = ApiMgtDAO.getInstance().retrieveIdentityScopes();
+            Map<Integer, Map<String, Scope>> scopesMap = ApiMgtDAO.getInstance().migrateIdentityScopes(identityScopes);
+
+            try {
+                for (Map.Entry<Integer, Map<String, Scope>> scopesMapEntry : scopesMap.entrySet()) {
+                    ScopesDAO scopesDAO = ScopesDAO.getInstance();
+                    Map<String, Scope> scopeMap = scopesMapEntry.getValue();
+                    if (scopeMap != null) {
+                        Set<Scope> scopeSet = new HashSet<>(scopeMap.values());
+                        scopesDAO.addScopes(scopeSet, scopesMapEntry.getKey());
+                    }
+                }
+                log.info("Successfully migrated identity scopes");
+            } catch (APIManagementException e) {
+                throw new APIMigrationException("Error occurred while migrating identity scopes", e);
+            }
+        }
+    }
+
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v320/dao/ApiMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v320/dao/ApiMgtDAO.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.migrator.v320.dao;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
+import org.wso2.carbon.apimgt.migration.APIMigrationException;
+import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class ApiMgtDAO {
+    private static final Log log = LogFactory.getLog(ApiMgtDAO.class);
+
+    private static ApiMgtDAO INSTANCE = null;
+
+    private static final String SELECT_SCOPES_QUERY_LEFT = "SELECT IDN_OAUTH2_SCOPE.SCOPE_ID AS SCOPE_ID," +
+            "IDN_OAUTH2_SCOPE.NAME AS SCOPE_KEY,IDN_OAUTH2_SCOPE.DISPLAY_NAME AS DISPLAY_NAME,IDN_OAUTH2_SCOPE" +
+            ".DESCRIPTION AS DESCRIPTION,IDN_OAUTH2_SCOPE.TENANT_ID AS TENANT_ID," +
+            "SCOPE_TYPE AS SCOPE_TYPE,IDN_OAUTH2_SCOPE_BINDING.SCOPE_BINDING AS SCOPE_BINDING " +
+            "FROM IDN_OAUTH2_SCOPE LEFT JOIN IDN_OAUTH2_SCOPE_BINDING ON IDN_OAUTH2_SCOPE" +
+            ".SCOPE_ID=IDN_OAUTH2_SCOPE_BINDING.SCOPE_ID WHERE IDN_OAUTH2_SCOPE.SCOPE_TYPE = 'OAUTH2' " +
+            "AND IDN_OAUTH2_SCOPE.NAME NOT IN (SCOPE_SKIP_LIST)";
+    private static final String IDENTITY_PATH = "identity";
+    private static final String NAME = "name";
+
+    public static ApiMgtDAO getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ApiMgtDAO();
+        }
+        return INSTANCE;
+    }
+
+    public Map<Integer, Map<String, Scope>>  migrateIdentityScopes(List<String> identityScopes) throws APIMigrationException {
+        String query = SELECT_SCOPES_QUERY_LEFT;
+        Map<Integer, Map<String, Scope>> scopesMap = new HashMap<>();
+        query = query.replaceAll("SCOPE_SKIP_LIST",
+                StringUtils.repeat("?", ",", identityScopes.size()));
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+                for (int i = 0; i < identityScopes.size(); i++) {
+                    preparedStatement.setString(i + 1, identityScopes.get(i));
+                }
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    while (resultSet.next()) {
+                        int scopeId = resultSet.getInt("SCOPE_ID");
+                        String scopeKey = resultSet.getString("SCOPE_KEY");
+                        String displayName = resultSet.getString("DISPLAY_NAME");
+                        String description = resultSet.getString("DESCRIPTION");
+                        int tenantId = resultSet.getInt("TENANT_ID");
+                        String scopeBinding = resultSet.getString("SCOPE_BINDING");
+                        Map<String, Scope> scopeMap = scopesMap.computeIfAbsent(tenantId,
+                                k -> new HashMap<>());
+                        Scope scope = scopeMap.get(scopeKey);
+                        if (scope == null) {
+                            scope = new Scope();
+                            scope.setId(Integer.toString(scopeId));
+                            scope.setKey(scopeKey);
+                            scope.setName(displayName);
+                            scope.setDescription(description);
+                            scopeMap.put(scopeKey, scope);
+                        }
+                        String roles = scope.getRoles();
+                        if (StringUtils.isNotEmpty(scopeBinding)) {
+                            if (StringUtils.isEmpty(roles)) {
+                                scope.setRoles(scopeBinding);
+                            } else {
+                                scope.setRoles(scope.getRoles().concat(",").concat(scopeBinding));
+                            }
+                        }
+                    }
+                    return scopesMap;
+                }
+            }
+        } catch (SQLException e) {
+            throw new APIMigrationException("Database error while migrating identity scopes ", e);
+        }
+    }
+
+    public boolean isScopesMigrated() throws APIMigrationException {
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement preparedStatement = connection
+                    .prepareStatement("SELECT 1 FROM AM_SCOPE WHERE SCOPE_TYPE = ?")) {
+                preparedStatement.setString(1, APIConstants.DEFAULT_SCOPE_TYPE);
+                ResultSet resultSet = preparedStatement.executeQuery();
+                if (resultSet.next()) {
+                    return true;
+                }
+            }
+        } catch (SQLException e) {
+            throw new APIMigrationException("Error while retrieving database connection", e);
+        }
+        return false;
+    }
+
+    public List<String> retrieveIdentityScopes() {
+
+        List<String> scopes = new ArrayList<>();
+        String configDirPath = CarbonUtils.getCarbonConfigDirPath();
+        String confXml = Paths.get(configDirPath, IDENTITY_PATH, OAuthConstants.OAUTH_SCOPE_BINDING_PATH)
+                .toString();
+        File configFile = new File(confXml);
+        if (!configFile.exists()) {
+            log.warn("OAuth scope binding file is not present at: " + confXml);
+            return new ArrayList<>();
+        }
+
+        XMLStreamReader parser = null;
+        InputStream stream = null;
+
+        try {
+            stream = new FileInputStream(configFile);
+            parser = XMLInputFactory.newInstance()
+                    .createXMLStreamReader(stream);
+            StAXOMBuilder builder = new StAXOMBuilder(parser);
+            OMElement documentElement = builder.getDocumentElement();
+            Iterator iterator = documentElement.getChildElements();
+            while (iterator.hasNext()) {
+                OMElement omElement = (OMElement) iterator.next();
+                String scopeName = omElement.getAttributeValue(new QName(NAME));
+                scopes.add(scopeName);
+            }
+        } catch (XMLStreamException e) {
+            log.warn("Error while parsing scope config.", e);
+        } catch (FileNotFoundException e) {
+            log.warn("Error while loading scope config.", e);
+        } finally {
+            try {
+                if (parser != null) {
+                    parser.close();
+                }
+                if (stream != null) {
+                    IdentityIOStreamUtils.closeInputStream(stream);
+                }
+            } catch (XMLStreamException e) {
+                log.error("Error while closing XML stream", e);
+            }
+        }
+        return scopes;
+    }
+}


### PR DESCRIPTION
## Purpose
Adds the identity scope migrator for the migration from APIM 3.1.0 to 3.2.0

## Goals
This migrator will be used to migrate the local scopes from `IDN_OAUTH2_SCOPE` table to the new `AM_SCOPE` table when migrating from APIM 3.1.0 to 3.2.0