### PR TITLE
[4.1.0 - Migration] Fix issues with KM migration from 3.1.0 to 3.2.0

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/dao/APIMgtDAO.java
@@ -194,7 +194,7 @@ public class APIMgtDAO {
 
     private static String GET_API_ID_OF_WS_APIS = "SELECT API_ID FROM AM_API WHERE API_TYPE = 'WS'";
     private static final String ADD_KEY_MANAGER =
-            " INSERT INTO AM_KEY_MANAGER (UUID,NAME,DESCRIPTION,TYPE,TENANT_DOMAIN,ORGANIZATION,ENABLED," +
+            " INSERT INTO AM_KEY_MANAGER (UUID,NAME,DESCRIPTION,TYPE,CONFIGURATION,TENANT_DOMAIN,ENABLED," +
                     "DISPLAY_NAME) VALUES (?,?,?,?,?,?,?,?)";
 
     private static String UPDATE_API_CATEGORY_ORGANIZATION =
@@ -1421,6 +1421,10 @@ public class APIMgtDAO {
                                 keyManagerConfigurationDTO.getName() + " in tenant " +
                                 keyManagerConfigurationDTO.getTenantDomain(), e);
                     }
+                } else {
+                    throw new APIMigrationException("Error while Storing key manager configuration with name " +
+                            keyManagerConfigurationDTO.getName() + " in tenant " +
+                            keyManagerConfigurationDTO.getTenantDomain(), e);
                 }
             }
         } catch (SQLException | IOException e) {

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v400/V400DBDataMigrator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v400/V400DBDataMigrator.java
@@ -171,6 +171,8 @@ public class V400DBDataMigrator extends Migrator {
 
         for (Tenant tenant : tenants) {
             //Add tenant specific resident key manager with uuids to the AM_KEY_MANAGER table
+            log.info("Adding default key manager and updating key mappings for tenant: "
+                    + tenant.getId() + "(" + tenant.getDomain() + ")");
             addDefaultKM(apiMgtDAO, tenant.getDomain());
             apiMgtDAO.replaceKeyMappingKMNamebyUUID(tenant);
             apiMgtDAO.replaceRegistrationKMNamebyUUID(tenant);


### PR DESCRIPTION
## Purpose
This PR fixes the following issue that comes up when trying to generate keys for migrated apps. This happens because the key managers are not being properly migrated in 3.1.0 to 3.2.0 migration step.

```
"[2022-06-04 20:01:36,654] ERROR - GlobalThrowableMapper An unknown exception has been captured by the global exception mapper.
java.lang.NullPointerException: null
        at org.wso2.carbon.apimgt.impl.APIConsumerImpl.getApplicationKeyByAppIDAndKeyMapping_aroundBody244(APIConsumerImpl.java:5513) ~[org.wso2.carbon.apimgt.impl-9.20.74.10-SNAPSHOT.jar:?]
        at org.wso2.carbon.apimgt.impl.APIConsumerImpl.getApplicationKeyByAppIDAndKeyMapping(APIConsumerImpl.java:5506) ~[org.wso2.carbon.apimgt.impl-9.20.74.10-SNAPSHOT.jar:?]
        at org.wso2.carbon.apimgt.rest.api.store.v1.impl.ApplicationsApiServiceImpl.getApplicationKeyByAppIDAndKeyMapping(ApplicationsApiServiceImpl.java:959) ~[?:?]
        at org.wso2.carbon.apimgt.rest.api.store.v1.impl.ApplicationsApiServiceImpl.applicationsApplicationIdOauthKeysKeyMappingIdGenerateTokenPost(ApplicationsApiServiceImpl.java:1169) ~[?:?]
        at org.wso2.carbon.apimgt.rest.api.store.v1.ApplicationsApi.applicationsApplicationIdOauthKeysKeyMappingIdGenerateTokenPost(ApplicationsApi.java:338) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_251]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_251]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_251]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_251]
        at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179) ~[?:?]
        at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96) ~[?:?]
        at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:201) ~[?:?]
        at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:104) ~[?:?]
        at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59) ~[?:?]
        at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96) ~[?:?]
        at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307) ~[?:?]
        at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121) ~[?:?]
        at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:265) ~[?:?]
        at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:234) ~[?:?]
        at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:208) ~[?:?]
        at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:160) ~[?:?]
        at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:225) ~[?:?]
        at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:304) ~[?:?]
        at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPost(AbstractHTTPServlet.java:217) ~[?:?]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:681) ~[tomcat-servlet-api_9.0.58.wso2v1.jar:?]
        at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:279) ~[?:?]
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:540) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:135) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:107) ~[org.wso2.carbon.identity.context.rewrite.valve_1.4.52.jar:?]
        at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:110) ~[org.wso2.carbon.identity.authz.valve_1.4.52.jar:?]
        at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:102) ~[org.wso2.carbon.identity.auth.valve_1.4.52.jar:?]
        at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:101) ~[org.wso2.carbon.tomcat.ext_4.6.3.jar:?]
        at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:49) ~[org.wso2.carbon.tomcat.ext_4.6.3.jar:?]
        at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62) ~[org.wso2.carbon.tomcat.ext_4.6.3.jar:?]
        at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:146) ~[org.wso2.carbon.tomcat.ext_4.6.3.jar:?]
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:687) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:58) ~[org.wso2.carbon.tomcat.ext_4.6.3.jar:?]
        at org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve.invoke(RequestCorrelationIdValve.java:126) ~[org.wso2.carbon.tomcat.ext_4.6.3.jar:?]
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:359) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:889) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1735) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat_9.0.58.wso2v1.jar:?]
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat_9.0.58.wso2v1.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_251]
"
```