### PR TITLE
[4.1.0 - Migration] Add a validator to check API availability

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -448,6 +448,7 @@ public class Constants {
     public static class preValidationService {
         public static final String API_DEFINITION_VALIDATION = "apiDefinitionValidation";
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
+        public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
     }
 
     /** Environment related constants **/

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.wso2.carbon.apimgt.migration.util;
 
@@ -175,7 +175,6 @@ public class Constants {
     public static final String SWAGGER_PRODUCES = "produces";
 
 
-
     // Work flow extensions
     public static final String WF_SUBSCRIPTION_DELETION_TAG = "SubscriptionDeletion";
     public static final String WF_EXECUTOR_ATTRIBUTE = "executor";
@@ -263,11 +262,11 @@ public class Constants {
     public static final String SWAGGER_CONSUMES = "consumes";
     public static final String DEFAULT_DATA_TYPE = "string";
 
-	public static final String API_KEY_VALIDATOR_ENCRYPT_TOKENS =
+    public static final String API_KEY_VALIDATOR_ENCRYPT_TOKENS =
             APIConstants.API_KEY_VALIDATOR + "EncryptPersistedTokens";
 
-    public static final String THROTTLING_CONFIGURATIONS ="ThrottlingConfigurations.";
-    public static final String ENABLE_THROTTLING_CONFIGURATIONS =THROTTLING_CONFIGURATIONS + "EnableAdvanceThrottling";
+    public static final String THROTTLING_CONFIGURATIONS = "ThrottlingConfigurations.";
+    public static final String ENABLE_THROTTLING_CONFIGURATIONS = THROTTLING_CONFIGURATIONS + "EnableAdvanceThrottling";
 
     public static final String SECURITY_DEFINITION__KEY = "securityDefinitions";
     public static final String SECURITY_DEFINITION_TYPE_KEY = "type";
@@ -402,10 +401,10 @@ public class Constants {
 
     // DB script paths
     public static String PRE_MIGRATION_SCRIPT_DIR = CarbonUtils.getCarbonHome() + File.separator + "migration-resources"
-            + File.separator + "migration-scripts"+ File.separator + "pre-migration-scripts" + File.separator;
+            + File.separator + "migration-scripts" + File.separator + "pre-migration-scripts" + File.separator;
 
     public static String POST_MIGRATION_SCRIPT_DIR = CarbonUtils.getCarbonHome() + File.separator
-            + "migration-resources" + File.separator + "migration-scripts"+ File.separator + "post-migration-scripts"
+            + "migration-resources" + File.separator + "migration-scripts" + File.separator + "post-migration-scripts"
             + File.separator;
 
     public static final String V300_PRE_MIGRATION_SCRIPTS_PATH = PRE_MIGRATION_SCRIPT_DIR + "migration-2.6.0_to_3.0.0"
@@ -451,7 +450,9 @@ public class Constants {
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
     }
 
-    /** Environment related constants **/
+    /**
+     * Environment related constants
+     **/
 
     public static final String GET_ENVIRONMENT_BY_TENANT_SQL =
             "SELECT ID, UUID, NAME, TENANT_DOMAIN, DISPLAY_NAME, DESCRIPTION " +

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
@@ -1,0 +1,41 @@
+package org.wso2.carbon.apimgt.migration.validator.dao;
+
+import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
+import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class ApiMgtDAO {
+    private static ApiMgtDAO INSTANCE = null;
+
+    public static ApiMgtDAO getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ApiMgtDAO();
+        }
+        return INSTANCE;
+    }
+
+    public int getAPIID(String provider, String name, String version) throws SQLException {
+
+        int id = -1;
+        String getAPIQuery = SQLConstants.GET_API_ID_SQL;
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement prepStmt = connection.prepareStatement(getAPIQuery)) {
+                prepStmt.setString(1, APIUtil.replaceEmailDomainBack(provider));
+                prepStmt.setString(2, name);
+                prepStmt.setString(3, version);
+                try (ResultSet rs = prepStmt.executeQuery()) {
+                    if (rs.next()) {
+                        id = rs.getInt("API_ID");
+                    }
+                }
+            }
+        }
+        return id;
+    }
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V410Validator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V410Validator.java
@@ -5,11 +5,13 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.definitions.AsyncApiParserUtil;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
 import org.wso2.carbon.apimgt.impl.wsdl.model.WSDLValidationResponse;
+import org.wso2.carbon.apimgt.migration.validator.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.migration.validator.utils.Utils;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.PublisherCommonUtils;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLValidationResponseDTO;
@@ -21,6 +23,7 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.sql.SQLException;
 
 public class V410Validator extends Validator {
     private static final Log log = LogFactory.getLog(V410Validator.class);
@@ -46,6 +49,21 @@ public class V410Validator extends Validator {
             }
         } else {
             validateStreamingAPIDefinition();
+        }
+    }
+
+    @Override
+    public void validateApiAvailability() {
+        try {
+            log.info("Validating API availability in db for API {name:" + apiName + ", version: " +
+                    apiVersion + ", provider: " + provider + "}");
+            int id = ApiMgtDAO.getInstance().getAPIID(provider, apiName, apiVersion);
+            if (id == -1) {
+                log.error("Unable to find the API " + "{name:" + apiName + ", version: " +
+                        apiVersion + ", provider: " + provider + "} in the database");
+            }
+        } catch (SQLException e) {
+            log.error("Error while getting the database connection ", e);
         }
     }
 

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V410Validator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V410Validator.java
@@ -55,11 +55,11 @@ public class V410Validator extends Validator {
     @Override
     public void validateApiAvailability() {
         try {
-            log.info("Validating API availability in db for API {name:" + apiName + ", version: " +
+            log.info("Validating API availability in db for API {name: " + apiName + ", version: " +
                     apiVersion + ", provider: " + provider + "}");
             int id = ApiMgtDAO.getInstance().getAPIID(provider, apiName, apiVersion);
             if (id == -1) {
-                log.error("Unable to find the API " + "{name:" + apiName + ", version: " +
+                log.error("Unable to find the API " + "{name: " + apiName + ", version: " +
                         apiVersion + ", provider: " + provider + "} in the database");
             }
         } catch (SQLException e) {
@@ -69,7 +69,8 @@ public class V410Validator extends Validator {
 
     public void validateOpenAPIDefinition() {
         APIDefinitionValidationResponse validationResponse = null;
-        log.info("Validating open API definition of  " + apiName + " version: " + apiVersion + " type: " + apiType);
+        log.info("Validating open API definition of API {name: " + apiName + ", version: " +
+                apiVersion + ", provider: " + provider + "}");
         try {
             String apiDefinition = utils.getAPIDefinition(registry, apiName, apiVersion, provider, apiId);
             validationResponse = OASParserUtil.validateAPIDefinition(apiDefinition, Boolean.TRUE);
@@ -79,8 +80,9 @@ public class V410Validator extends Validator {
         }
         if (validationResponse != null && !validationResponse.isValid()) {
             for (ErrorHandler error : validationResponse.getErrorItems()) {
-                log.error("Open API Definition is invalid. ErrorMessage: " + error.getErrorMessage()
-                        + " ErrorDescription: " + error.getErrorDescription());
+                log.error("OpenAPI Definition for API {name: " + apiName + ", version: " +
+                        apiVersion + ", provider: " + provider + "}" + " is invalid. ErrorMessage: " +
+                        error.getErrorMessage() + " ErrorDescription: " + error.getErrorDescription());
             }
         } else {
             log.info("Successfully validated open API definition of " + apiName + " version: " + apiVersion

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
@@ -48,10 +48,14 @@ public abstract class Validator {
             validateEndpoints();
         } else if (Constants.preValidationService.API_DEFINITION_VALIDATION.equals(preMigrationStep)) {
             validateAPIDefinition();
+        } else if (Constants.preValidationService.API_AVAILABILITY_VALIDATION.equals(preMigrationStep)) {
+            validateApiAvailability();
         }
     }
 
     public abstract void validateEndpoints();
 
     public abstract void validateAPIDefinition();
+
+    public abstract void validateApiAvailability();
 }


### PR DESCRIPTION
## Purpose
- Add a new validator to validate the availability of the APIs in the database. This is done by comparing the API artifacts in the registry with the API entries in the database.
- Update the validator flow to run all available validators or selected validators. If the user gives `-DrunPreMigration` only, all the available validators will be run. If its given as `-DrunPreMigration=apiDefinitionValidation`, only the API definition validator will be run.
