### PR TITLE
[4.1.0] Add capability to save invalid swaggers during pre-migration

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -449,6 +449,7 @@ public class Constants {
         public static final String API_DEFINITION_VALIDATION = "apiDefinitionValidation";
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
+        public static final String SAVE_INVALID_DEFINITION = "saveInvalidDefinition";
     }
 
     /**

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/utils/Utils.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/utils/Utils.java
@@ -12,7 +12,10 @@ import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.utils.CarbonUtils;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
@@ -132,5 +135,21 @@ public abstract class Utils {
 
     public String getMigrateFromVersion() {
         return migrateFromVersion;
+    }
+
+    public void saveInvalidDefinition(String apiId, String apiDefinition) {
+        String dirName = CarbonUtils.getCarbonHome() + File.separator + "migration-resources" + File.separator + "definitions";
+        String fileName = dirName + File.separator + apiId + ".json";
+        File directory = new File(dirName);
+        if (!directory.exists()) {
+            directory.mkdir();
+        }
+        try (FileOutputStream outStream = new FileOutputStream(fileName)) {
+            byte[] definitionBytes = apiDefinition.getBytes();
+            outStream.write(definitionBytes);
+            log.info("Invalid definition saved successfully to " + apiId + ".json");
+        } catch (IOException e) {
+            log.error("Error while saving the invalid swagger definition to the file: " + fileName, e);
+        }
     }
 }


### PR DESCRIPTION
## Purpose
This adds the capability to save the invalid swagger definitions during the migration pre-validation step. 
`-DsaveInvalidDefinition` flag can be used to enable this during the pre-validation step. This will save the relevant swagger definitions to the `definitions` directory in `migration-resources` in the `<API_UUID>.json` format.

Sample command

```
sh api-manager.sh -Dmigrate -DmigrateFromVersion=2.6.0 -DmigratedVersion=4.1.0 -DrunPreMigration=apiDefinitionValidation -DsaveInvalidDefinition
 ```