### PR TITLE
LifeCycle Migrations added

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v420/V420RegistryResourceMigrator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v420/V420RegistryResourceMigrator.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.apimgt.migration.migrator.v420;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -24,26 +26,53 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.internal.ServiceHolder;
 import org.wso2.carbon.apimgt.migration.migrator.commonMigrators.RegistryResourceMigrator;
+import org.wso2.carbon.apimgt.migration.util.APIUtil;
 import org.wso2.carbon.apimgt.migration.util.Constants;
+import org.wso2.carbon.apimgt.persistence.APIConstants;
+import org.wso2.carbon.apimgt.persistence.utils.RegistryPersistenceUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
+import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
+import org.wso2.carbon.governance.api.util.GovernanceUtils;
+import org.wso2.carbon.governance.lcm.util.CommonUtil;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+
 
 public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
     private static final Log log = LogFactory.getLog(V420RegistryResourceMigrator.class);
@@ -57,6 +86,83 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
     public void migrate() throws APIMigrationException {
         super.migrate();
         registryDataPopulation();
+    }
+
+    private JSONObject returnLifeCycleAsJson(String lcXML) throws ParserConfigurationException, IOException, SAXException {
+        JSONObject LCConfigObj = new JSONObject();
+        JSONArray statesArray = new JSONArray();
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new InputSource(new StringReader(lcXML)));
+
+        Element root = doc.getDocumentElement();
+        NodeList states = root.getElementsByTagName("state");
+        int nStates = states.getLength();
+
+        JSONObject stateObj;
+        for (int i = 0; i < nStates; i++) {
+            stateObj = new JSONObject();
+            Node node = states.item(i);
+            Node id = node.getAttributes().getNamedItem("id");
+
+            stateObj.put("State", id.getNodeValue());
+
+            if (id != null && !id.getNodeValue().isEmpty()) {
+                NodeList stateChildNodes = node.getChildNodes();
+                int nItems = stateChildNodes.getLength();
+                JSONArray transitionArray = new JSONArray();
+                JSONArray checkListItems = new JSONArray();
+
+                for (int j = 0; j < nItems; j++) {
+                    Node transition = stateChildNodes.item(j);
+                    // Add transitions
+                    if ("transition".equals(transition.getNodeName())) {
+                        Node target = transition.getAttributes().getNamedItem("target");
+                        Node action = transition.getAttributes().getNamedItem("event");
+                        if (target != null && action != null) {
+                            transitionArray.add(getTransitionObj(action.getNodeValue(), target.getNodeValue()));
+                        }
+                    }
+
+                    if ("datamodel".equals(transition.getNodeName())) {
+                        NodeList datamodels = transition.getChildNodes();
+                        int nDatamodel = datamodels.getLength();
+                        for (int k = 0; k < nDatamodel; k++) {
+                            Node dataNode = datamodels.item(k);
+                            if (dataNode != null && dataNode.getAttributes() != null && "checkItems"
+                                    .equals(dataNode.getAttributes().getNamedItem("name").getNodeValue())) {
+                                NodeList items = dataNode.getChildNodes();
+                                for (int x = 0; x < items.getLength(); x++) {
+                                    Node item = items.item(x);
+                                    if (item != null && item.getAttributes() != null
+                                            && item.getAttributes().getNamedItem("name") != null) {
+                                        checkListItems.add(item.getAttributes().getNamedItem("name").getNodeValue());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (transitionArray.size() > 0) stateObj.put("Transitions", transitionArray);
+                    if (checkListItems.size() > 0) stateObj.put("CheckItems", checkListItems);
+                }
+            }
+            statesArray.add(stateObj);
+            LCConfigObj.put("States", statesArray);
+
+//            ObjectMapper mapper = new ObjectMapper();
+//            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+//            mapper.writeValue(new File("LCConfig.json"), LCConfigObj);
+        }
+        return LCConfigObj;
+    }
+
+    private static JSONObject getTransitionObj(String event, String target) {
+
+        JSONObject transitionObj = new JSONObject();
+        transitionObj.put("Event", event);
+        transitionObj.put("Target", target);
+        return transitionObj;
     }
 
     private void registryDataPopulation() throws APIMigrationException {
@@ -78,6 +184,8 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId, true);
                 ServiceHolder.getTenantRegLoader().loadTenantRegistry(tenantId);
                 UserRegistry registry = ServiceHolder.getRegistryService().getGovernanceSystemRegistry(tenantId);
+                String defaultLifecyclePath = CommonUtil.getDefaltLifecycleConfigLocation() + File.separator
+                        + APIConstants.API_LIFE_CYCLE + APIConstants.XML_EXTENSION;
 
                 log.info("WSO2 API-M Migration Task : Starting data migration of Self Signup Configuration for tenant "
                         + tenantId + '(' + tenantDomain + ')');
@@ -138,6 +246,57 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
                 }
                 log.info("WSO2 API-M Migration Task : Completed data migration of Self Signup Configuration for tenant "
                         + tenantId + '(' + tenantDomain + ')');
+
+                File file = new File(defaultLifecyclePath);
+                if (file != null && file.exists()) {
+                    String lcXML = FileUtils.readFileToString(file);
+
+                    JSONObject States = returnLifeCycleAsJson(lcXML);
+                    String currentConfig = ServiceReferenceHolder.getInstance().getApimConfigService()
+                            .getTenantConfig(tenantDomain);
+                    JsonObject currentConfigJsonObject = (JsonObject) new JsonParser().parse(currentConfig);
+                    JsonObject StateJsonObject = (JsonObject) new JsonParser().parse(States.toString());
+                    currentConfigJsonObject.add("LifeCycle",StateJsonObject);
+                    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                    String formattedTenantConf = gson.toJson(currentConfigJsonObject);
+                    ServiceReferenceHolder.getInstance().getApimConfigService()
+                            .updateTenantConfig(tenantDomain, formattedTenantConf);
+                }else{
+                    log.info("LifeCycleDoesn't found");
+                }
+
+                GenericArtifactManager artifactManager = APIUtil.getArtifactManager(registry, APIConstants.API_KEY);
+
+                if (artifactManager != null) {
+                    GenericArtifact[] artifacts = artifactManager.getAllGenericArtifacts();
+                    log.info("Artifacts Length:"+artifacts.length);
+                    for (GenericArtifact artifact : artifacts) {
+                        String aspect = "APILifeCycle";
+
+                        if(artifact.getPath().contains("/apimgt/applicationdata/provider")){
+                            GenericArtifact apiArtifact = artifactManager.getGenericArtifact(artifact.getId());
+                            API api = RegistryPersistenceUtil.getApiForPublishing(registry, apiArtifact);
+                            APIIdentifier apiId = api.getId();
+                            String path = RegistryPersistenceUtil.getAPIPath(apiId);
+
+                            //Detaching the APILifeCycle
+                            GovernanceUtils.removeAspect(path, aspect, registry);
+                        }
+
+                        String apiOverviewStatus = artifact.getAttribute(Constants.API_OVERVIEW_STATUS);
+                        String lcState =  artifact.getLifecycleState();
+                        log.info("API_OVERVIEW_STATUS: "+apiOverviewStatus);
+                        log.info("lcState: "+lcState);
+
+                        if(!apiOverviewStatus.equals(lcState) && lcState!=null){
+                            artifact.setAttribute(Constants.API_OVERVIEW_STATUS,lcState);
+                        }
+
+                    }
+                }else{
+                    log.info("ArtifactManager Is Null");
+                }
+
             } catch (APIManagementException e) {
                 log.error(
                         "WSO2 API-M Migration Task : Error occurred while migrating Self Signup Configuration for tenant "
@@ -154,6 +313,18 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
                 log.error(
                         "WSO2 API-M Migration Task : Error occurred while converting the XML string to OMElement for tenant "
                                 + tenantId + '(' + tenantDomain + ')', e);
+                isError = true;
+                continue;
+            } catch (IOException e) {
+                log.error("WSO2 API-M Migration Task : Error occurred while getting the Lifecycle XML ");
+                isError = true;
+                continue;
+            } catch (ParserConfigurationException e) {
+                log.error("WSO2 API-M Migration Task : Error occurred while parsing Lifecycle XML ");
+                isError = true;
+                continue;
+            } catch (SAXException e) {
+                log.error("WSO2 API-M Migration Task : Error occurred while parsing Lifecycle XML ");
                 isError = true;
                 continue;
             } finally {

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v420/V420RegistryResourceMigrator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v420/V420RegistryResourceMigrator.java
@@ -83,7 +83,7 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
         tenants = loadTenants();
     }
 
-    protected static JSONObject getTransitionObj(String event, String target) {
+    private static JSONObject getTransitionObj(String event, String target) {
 
         JSONObject transitionObj = new JSONObject();
         transitionObj.put("Event", event);

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v420/V420RegistryResourceMigrator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v420/V420RegistryResourceMigrator.java
@@ -281,14 +281,13 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
 
                 if (artifactManager != null) {
                     GenericArtifact[] artifacts = artifactManager.getAllGenericArtifacts();
-                    log.info("Artifacts Length:" + artifacts.length);
+                    log.info("Artifacts Length: " + artifacts.length);
                     for (GenericArtifact artifact : artifacts) {
                         String aspect = "APILifeCycle";
 
                         String apiOverviewStatus = artifact.getAttribute(Constants.API_OVERVIEW_STATUS);
                         String lcState = artifact.getLifecycleState();
-                        log.info("API_OVERVIEW_STATUS: " + apiOverviewStatus);
-                        log.info("lcState: " + lcState);
+                        log.info("API_ID: "+artifact.getId() + " : API_OVERVIEW_STATUS: " + apiOverviewStatus+" lcState: " + lcState);
 
                         if (!apiOverviewStatus.equals(lcState) && lcState != null) {
                             artifact.setAttribute(Constants.API_OVERVIEW_STATUS, lcState);
@@ -306,7 +305,7 @@ public class V420RegistryResourceMigrator extends RegistryResourceMigrator {
 
                     }
                 } else {
-                    log.info("ArtifactManager Is Null");
+                    throw new APIMigrationException("Artifact Manager is Null");
                 }
 
             } catch (APIManagementException e) {

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -333,6 +333,7 @@ public class Constants {
     public static final String API_OVERVIEW_VERSION = "overview_version";
     public static final String API_OVERVIEW_PROVIDER = "overview_provider";
     public static final String API_OVERVIEW_CONTEXT = "overview_context";
+    public static final String API_OVERVIEW_STATUS = "overview_status";
     public static final String API_OVERVIEW_WSDL = "overview_wsdl";
     public static final String API_OVERVIEW_VERSION_COMPARABLE = "overview_versionComparable";
     public static final String[] HTTP_DEFAULT_METHODS = {"GET", "PUT", "POST", "DELETE", "PATCH"};


### PR DESCRIPTION
## Purpose
> Migrate LifeCycle config from registry to Advance Configuration

## Related PRs
> This fixes wso2/api-manager#364
> Migration Fix for the wso2/api-manager#314

## Migrations
1. Read the LifeCycle.xml file in each tenant and convert that to a respective LifeCycle Object.
2. Add the converted lifecycle object to tenant-conf.json(or Advanced Configuration of the tenant)
3. Detach the APILifeCycle from the Registry	
4. Pre-validation to validate whether lcState is same as the overview_status of the API
