### PR TITLE
Add api resource level auth scheme prevalidation step

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -449,6 +449,7 @@ public class Constants {
         public static final String API_DEFINITION_VALIDATION = "apiDefinitionValidation";
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
+        public static final String API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION = "apiResourceLevelAuthSchemeValidation";
         public static final String SAVE_INVALID_DEFINITION = "saveInvalidDefinition";
     }
 

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
@@ -34,8 +34,11 @@ public class ValidationHandler {
     private String tenantArguments = System.getProperty(Constants.ARG_MIGRATE_TENANTS);
     private final String tenantRangeArgs = System.getProperty(Constants.ARG_MIGRATE_TENANTS_RANGE);
     private String blackListTenantArguments = System.getProperty(Constants.ARG_MIGRATE_BLACKLIST_TENANTS);
-    private final String[] validatorList = {Constants.preValidationService.API_AVAILABILITY_VALIDATION,
-            Constants.preValidationService.API_DEFINITION_VALIDATION};
+    private final String[] validatorList = {
+            Constants.preValidationService.API_AVAILABILITY_VALIDATION,
+            Constants.preValidationService.API_DEFINITION_VALIDATION,
+            Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION,
+    };
     private final Validator validator;
 
     public ValidationHandler(String migrateFromVersion, String migratedVersion) {

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
@@ -56,7 +56,6 @@ public class ApiMgtDAO {
                 ps.setInt(1, apiId);
                 try (ResultSet resultSet = ps.executeQuery();) {
                     while (resultSet.next()) {
-
                         String script = null;
                         URITemplate uriTemplate = new URITemplate();
                         uriTemplate.setUriTemplate(resultSet.getString("URL_PATTERN"));
@@ -78,7 +77,6 @@ public class ApiMgtDAO {
         } catch (SQLException e) {
             log.error("Error on retrieving URLTemplates for apiResourceLevelAuthSchemeValidation validation", e);
         }
-
         return urlTemplates;
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
@@ -1,15 +1,23 @@
 package org.wso2.carbon.apimgt.migration.validator.dao;
 
-import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.migration.validator.dao.constants.SQLConstants;
 
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ApiMgtDAO {
+    private static final Log log = LogFactory.getLog(ApiMgtDAO.class);
+
     private static ApiMgtDAO INSTANCE = null;
 
     public static ApiMgtDAO getInstance() {
@@ -37,5 +45,40 @@ public class ApiMgtDAO {
             }
         }
         return id;
+    }
+
+    public Set<URITemplate> getURITemplatesByAPIID(int apiId) {
+
+        Set<URITemplate> urlTemplates = new HashSet<>();
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement ps = connection.prepareStatement(SQLConstants.GET_URL_TEMPLATES_BY_API_ID_SQL_260)) {
+                ps.setInt(1, apiId);
+                try (ResultSet resultSet = ps.executeQuery();) {
+                    while (resultSet.next()) {
+
+                        String script = null;
+                        URITemplate uriTemplate = new URITemplate();
+                        uriTemplate.setUriTemplate(resultSet.getString("URL_PATTERN"));
+                        uriTemplate.setHTTPVerb(resultSet.getString("HTTP_METHOD"));
+                        uriTemplate.setAuthType(resultSet.getString("AUTH_SCHEME"));
+                        uriTemplate.setThrottlingTier(resultSet.getString("THROTTLING_TIER"));
+                        InputStream mediationScriptBlob = resultSet.getBinaryStream("MEDIATION_SCRIPT");
+                        if (mediationScriptBlob != null) {
+                            script = APIMgtDBUtil.getStringFromInputStream(mediationScriptBlob);
+                            if (script.isEmpty()) {
+                                script = null;
+                            }
+                        }
+                        uriTemplate.setMediationScript(script);
+                        urlTemplates.add(uriTemplate);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error on retrieving URLTemplates for apiResourceLevelAuthSchemeValidation validation", e);
+        }
+
+        return urlTemplates;
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
@@ -1,0 +1,27 @@
+package org.wso2.carbon.apimgt.migration.validator.dao.constants;
+
+public class SQLConstants {
+    public static final String GET_API_ID_SQL =
+            "SELECT     " +
+                    "   API.API_ID " +
+                    " FROM " +
+                    "   AM_API API " +
+                    " WHERE " +
+                    "   API.API_PROVIDER = ? " +
+                    "   AND API.API_NAME = ? " +
+                    "   AND API.API_VERSION = ? ";
+
+    public static final String GET_URL_TEMPLATES_BY_API_ID_SQL_260 =
+            " SELECT " +
+                    "   URL_PATTERN," +
+                    "   HTTP_METHOD," +
+                    "   AUTH_SCHEME," +
+                    "   THROTTLING_TIER, " +
+                    "   MEDIATION_SCRIPT " +
+                    " FROM " +
+                    "   AM_API_URL_MAPPING " +
+                    " WHERE " +
+                    "   API_ID = ? " +
+                    " ORDER BY " +
+                    "   URL_MAPPING_ID ASC ";
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
@@ -1,3 +1,20 @@
+ /*
+  *  Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  *
+  *  WSO2 Inc. licenses this file to you under the Apache License,
+  *  Version 2.0 (the "License"); you may not use this file except
+  *  in compliance with the License.
+  *  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License.
+  */
 package org.wso2.carbon.apimgt.migration.validator.dao.constants;
 
 public class SQLConstants {

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
@@ -50,6 +50,8 @@ public abstract class Validator {
             validateAPIDefinition();
         } else if (Constants.preValidationService.API_AVAILABILITY_VALIDATION.equals(preMigrationStep)) {
             validateApiAvailability();
+        } else if (Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION.equals(preMigrationStep)) {
+            validateApiResourceLevelAuthScheme();
         }
     }
 
@@ -58,4 +60,7 @@ public abstract class Validator {
     public abstract void validateAPIDefinition();
 
     public abstract void validateApiAvailability();
+
+    public abstract void validateApiResourceLevelAuthScheme();
+
 }


### PR DESCRIPTION
## Purpose
Add api resource level auth scheme pre-validation step for older 2.x versions as 'Application' & ' Application_User' auth schemes are not supported anymore.
Fixing https://github.com/wso2/api-manager/issues/601

## Approach
Warnings will be displayed for api resources using the unsupported auth schemes

## Migrations
2.6.0 to 4.1.0 migrations were done on MySQL, PostgreSQL
