### PR TITLE
Add Prevalidation step to warn about third party key-manager usage

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -450,6 +450,7 @@ public class Constants {
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
         public static final String API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION = "apiResourceLevelAuthSchemeValidation";
+        public static final String APP_THIRD_PARTY_KM_VALIDATION = "appThirdPartyKMValidation";
         public static final String SAVE_INVALID_DEFINITION = "saveInvalidDefinition";
     }
 

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
@@ -9,8 +9,11 @@ import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.client.internal.ServiceHolder;
 import org.wso2.carbon.apimgt.migration.migrator.Utility;
 import org.wso2.carbon.apimgt.migration.util.Constants;
+import org.wso2.carbon.apimgt.migration.validator.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.migration.validator.utils.Utils;
 import org.wso2.carbon.apimgt.migration.validator.utils.UtilsFactory;
+import org.wso2.carbon.apimgt.migration.validator.validators.ApplicationValidator;
 import org.wso2.carbon.apimgt.migration.validator.validators.Validator;
 import org.wso2.carbon.apimgt.migration.validator.validators.ValidatorFactory;
 import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
@@ -27,6 +30,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class ValidationHandler {
     private static final Log log = LogFactory.getLog(ValidationHandler.class);
@@ -39,28 +43,48 @@ public class ValidationHandler {
             Constants.preValidationService.API_DEFINITION_VALIDATION,
             Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION,
     };
+    private final String[] applicationValidatorList = {
+            Constants.preValidationService.APP_THIRD_PARTY_KM_VALIDATION,
+    };
     private final Validator validator;
+    private final ApplicationValidator applicationValidator;
 
     public ValidationHandler(String migrateFromVersion, String migratedVersion) {
         UtilsFactory utilsFactory = new UtilsFactory();
         Utils utils = utilsFactory.getVersionUtils(migrateFromVersion);
         ValidatorFactory validatorFactory = new ValidatorFactory(utils);
         this.validator = validatorFactory.getVersionValidator(migratedVersion);
+        this.applicationValidator = new ApplicationValidator(utils);
     }
 
     public void doValidation() throws UserStoreException, APIMigrationException {
-        List<Tenant> tenants = loadTenants();
         if (Arrays.asList(validatorList).contains(preMigrationStep)) {
-            for (Tenant tenant : tenants) {
-                validateRegistryData(tenant, preMigrationStep);
-            }
+            doTenantValidation(preMigrationStep);
+        } else if (Arrays.asList(applicationValidatorList).contains(preMigrationStep)) {
+            doApplicationValidation(preMigrationStep);
         } else {
             log.info("Running all validator steps.........");
             for (String validatorStep : validatorList) {
-                for (Tenant tenant : tenants) {
-                    validateRegistryData(tenant, validatorStep);
-                }
+                doTenantValidation(validatorStep);
             }
+            for (String appValidatorStep : applicationValidatorList) {
+                doApplicationValidation(appValidatorStep);
+            }
+
+        }
+    }
+
+    private void doTenantValidation(String preMigrationStep) throws UserStoreException, APIMigrationException {
+        List<Tenant> tenants = loadTenants();
+        for (Tenant tenant : tenants) {
+            validateRegistryData(tenant, preMigrationStep);
+        }
+    }
+
+    private void doApplicationValidation(String preMigrationStep) {
+        List<ApplicationDTO> applications = loadApplications();
+        for (ApplicationDTO application : applications) {
+            applicationValidator.validate(application, preMigrationStep);
         }
     }
 
@@ -170,5 +194,10 @@ public class ValidationHandler {
             }
         }
         return tenantsArray;
+    }
+
+    private List<ApplicationDTO> loadApplications() {
+        Set<ApplicationDTO> applications = ApiMgtDAO.getInstance().getALlApplications();
+        return new ArrayList<>(applications);
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.apimgt.migration.validator;
 
 import org.apache.commons.logging.Log;
@@ -59,8 +76,10 @@ public class ValidationHandler {
 
     public void doValidation() throws UserStoreException, APIMigrationException {
         if (Arrays.asList(validatorList).contains(preMigrationStep)) {
+            log.info("Running validator step : " + preMigrationStep + " for tenants");
             doTenantValidation(preMigrationStep);
         } else if (Arrays.asList(applicationValidatorList).contains(preMigrationStep)) {
+            log.info("Running validator step : " + preMigrationStep + " for applications");
             doApplicationValidation(preMigrationStep);
         } else {
             log.info("Running all validator steps.........");
@@ -74,6 +93,12 @@ public class ValidationHandler {
         }
     }
 
+    /**
+     * Do tenant wise validations by iterating all tenants
+     * @param preMigrationStep pre-validation step to run
+     * @throws UserStoreException if an error occurs in tenant loading
+     * @throws APIMigrationException if an error occurs while accessing registry
+     */
     private void doTenantValidation(String preMigrationStep) throws UserStoreException, APIMigrationException {
         List<Tenant> tenants = loadTenants();
         for (Tenant tenant : tenants) {
@@ -81,6 +106,10 @@ public class ValidationHandler {
         }
     }
 
+    /**
+     * Do application wise validation by iterating all applications
+     * @param preMigrationStep pre-validation step to run
+     */
     private void doApplicationValidation(String preMigrationStep) {
         List<ApplicationDTO> applications = loadApplications();
         for (ApplicationDTO application : applications) {
@@ -197,7 +226,7 @@ public class ValidationHandler {
     }
 
     private List<ApplicationDTO> loadApplications() {
-        Set<ApplicationDTO> applications = ApiMgtDAO.getInstance().getALlApplications();
+        Set<ApplicationDTO> applications = ApiMgtDAO.getInstance().getAllApplications();
         return new ArrayList<>(applications);
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
@@ -1,11 +1,15 @@
 package org.wso2.carbon.apimgt.migration.validator.dao;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.migration.validator.dao.constants.SQLConstants;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationKeyMappingDTO;
 
 import java.io.InputStream;
 import java.sql.Connection;
@@ -78,5 +82,77 @@ public class ApiMgtDAO {
             log.error("Error on retrieving URLTemplates for apiResourceLevelAuthSchemeValidation validation", e);
         }
         return urlTemplates;
+    }
+
+    public Set<ApplicationDTO> getALlApplications() {
+        final String query = SQLConstants.GET_ALL_APPLICATIONS;
+
+        Set<ApplicationDTO> applications = new HashSet<>();
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    while (resultSet.next()) {
+                        ApplicationDTO application = new ApplicationDTO();
+                        application.setApplicationId(resultSet.getInt("APPLICATION_ID"));
+                        application.setName(resultSet.getString("NAME"));
+                        application.setSubscriberId(resultSet.getString("SUBSCRIBER_ID"));
+                        application.setStatus(resultSet.getString("APPLICATION_STATUS"));
+                        application.setCreatedBy(resultSet.getString("CREATED_BY"));
+                        application.setUuid(resultSet.getString("UUID"));
+                        applications.add(application);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error on retrieving Applications for appThirdPartyKMValidation", e);
+        }
+
+        return applications;
+    }
+
+    public Set<ApplicationKeyMappingDTO> getKeyMappingFromApplicationId(int applicationId) {
+        final String query = SQLConstants.GET_APPLICATION_KEY_MAPPING_BY_APP_ID_AND_KEY_TYPE;
+
+        Set<ApplicationKeyMappingDTO> applicationKeyMappings = new HashSet<>();
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement ps = connection.prepareStatement(query)) {
+                ps.setInt(1, applicationId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        ApplicationKeyMappingDTO applicationKeyMappingDTO = new ApplicationKeyMappingDTO();
+                        applicationKeyMappingDTO.setApplicationId(rs.getInt("APPLICATION_ID"));
+                        applicationKeyMappingDTO.setConsumerKey(rs.getString("CONSUMER_KEY"));
+                        applicationKeyMappingDTO.setKeyType(rs.getString("KEY_TYPE"));
+                        applicationKeyMappingDTO.setState(rs.getString("STATE"));
+                        String createMode = rs.getString("CREATE_MODE");
+                        if (StringUtils.isEmpty(createMode)) {
+                            createMode = APIConstants.OAuthAppMode.CREATED.name();
+                        }
+                        applicationKeyMappingDTO.setCreatedMode(createMode);
+                        applicationKeyMappings.add(applicationKeyMappingDTO);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error on retrieving Application Key Mappings for appThirdPartyKMValidation", e);
+        }
+        return applicationKeyMappings;
+    }
+
+    public boolean isThirdPartyKeyManagerUsed(String consumerKey) {
+        final String query = SQLConstants.GET_IDN_OAUTH_CONSUMER_APPS_CONSUMER_SECRET_IF_EXIST;
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement ps = connection.prepareStatement(query)) {
+                ps.setString(1, consumerKey);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return !rs.next();
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error on retrieving Consumer Secret for appThirdPartyKMValidation", e);
+        }
+        return true;
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.apimgt.migration.validator.dao;
 
 import org.apache.commons.lang3.StringUtils;
@@ -84,11 +101,9 @@ public class ApiMgtDAO {
         return urlTemplates;
     }
 
-    public Set<ApplicationDTO> getALlApplications() {
+    public Set<ApplicationDTO> getAllApplications() {
         final String query = SQLConstants.GET_ALL_APPLICATIONS;
-
         Set<ApplicationDTO> applications = new HashSet<>();
-
         try (Connection connection = APIMgtDBUtil.getConnection()) {
             try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
                 try (ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -107,7 +122,6 @@ public class ApiMgtDAO {
         } catch (SQLException e) {
             log.error("Error on retrieving Applications for appThirdPartyKMValidation", e);
         }
-
         return applications;
     }
 
@@ -140,19 +154,19 @@ public class ApiMgtDAO {
         return applicationKeyMappings;
     }
 
-    public boolean isThirdPartyKeyManagerUsed(String consumerKey) {
-        final String query = SQLConstants.GET_IDN_OAUTH_CONSUMER_APPS_CONSUMER_SECRET_IF_EXIST;
+    public boolean checkIfConsumerAppExists(String consumerKey) {
+        final String query = SQLConstants.GET_IF_IDN_OAUTH_CONSUMER_APP_EXISTS;
 
         try (Connection connection = APIMgtDBUtil.getConnection()) {
             try (PreparedStatement ps = connection.prepareStatement(query)) {
                 ps.setString(1, consumerKey);
                 try (ResultSet rs = ps.executeQuery()) {
-                    return !rs.next();
+                    return rs.next();
                 }
             }
         } catch (SQLException e) {
             log.error("Error on retrieving Consumer Secret for appThirdPartyKMValidation", e);
         }
-        return true;
+        return false;
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
@@ -62,11 +62,9 @@ public class SQLConstants {
                     "   AM_APPLICATION_KEY_MAPPING APP_KM   " +
                     " WHERE " +
                     "   APP_KM.APPLICATION_ID = ?   ";
-    public static final String GET_IDN_OAUTH_CONSUMER_APPS_CONSUMER_SECRET_IF_EXIST =
+    public static final String GET_IF_IDN_OAUTH_CONSUMER_APP_EXISTS =
             "SELECT" +
-                    "   OC_APP.ID,  " +
-                    "   OC_APP.CONSUMER_KEY,    " +
-                    "   OC_APP.CONSUMER_SECRET  " +
+                    "   1  " +
                     " FROM " +
                     "   IDN_OAUTH_CONSUMER_APPS OC_APP  " +
                     " WHERE " +

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
@@ -41,4 +41,34 @@ public class SQLConstants {
                     "   API_ID = ? " +
                     " ORDER BY " +
                     "   URL_MAPPING_ID ASC ";
+    public static final String GET_ALL_APPLICATIONS =
+            " SELECT " +
+                    "   APP.APPLICATION_ID,   " +
+                    "   APP.NAME,   " +
+                    "   APP.SUBSCRIBER_ID,   " +
+                    "   APP.APPLICATION_STATUS,   " +
+                    "   APP.CREATED_BY,   " +
+                    "   APP.UUID   " +
+                    " FROM " +
+                    "   AM_APPLICATION APP   ";
+    public static final String GET_APPLICATION_KEY_MAPPING_BY_APP_ID_AND_KEY_TYPE =
+            "SELECT " +
+                    "   APP_KM.APPLICATION_ID,  " +
+                    "   APP_KM.CONSUMER_KEY,    " +
+                    "   APP_KM.KEY_TYPE,    " +
+                    "   APP_KM.STATE,   " +
+                    "   APP_KM.CREATE_MODE  " +
+                    " FROM " +
+                    "   AM_APPLICATION_KEY_MAPPING APP_KM   " +
+                    " WHERE " +
+                    "   APP_KM.APPLICATION_ID = ?   ";
+    public static final String GET_IDN_OAUTH_CONSUMER_APPS_CONSUMER_SECRET_IF_EXIST =
+            "SELECT" +
+                    "   OC_APP.ID,  " +
+                    "   OC_APP.CONSUMER_KEY,    " +
+                    "   OC_APP.CONSUMER_SECRET  " +
+                    " FROM " +
+                    "   IDN_OAUTH_CONSUMER_APPS OC_APP  " +
+                    " WHERE " +
+                    "   OC_APP.CONSUMER_KEY = ?";
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationDTO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationDTO.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.migration.validator.dto;
+
+public class ApplicationDTO {
+    private int applicationId;
+    private String name;
+    private String subscriberId;
+    private String status;
+    private String createdBy;
+    private String uuid;
+
+    public int getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(int applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSubscriberId() {
+        return subscriberId;
+    }
+
+    public void setSubscriberId(String subscriberId) {
+        this.subscriberId = subscriberId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationKeyMappingDTO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationKeyMappingDTO.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.migration.validator.dto;
+
+public class ApplicationKeyMappingDTO {
+    private int applicationId;
+    private String consumerKey;
+    private String keyType;
+    private String state;
+    private String createdMode;
+
+    public int getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(int applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getConsumerKey() {
+        return consumerKey;
+    }
+
+    public void setConsumerKey(String consumerKey) {
+        this.consumerKey = consumerKey;
+    }
+
+    public String getKeyType() {
+        return keyType;
+    }
+
+    public void setKeyType(String keyType) {
+        this.keyType = keyType;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getCreatedMode() {
+        return createdMode;
+    }
+
+    public void setCreatedMode(String createdMode) {
+        this.createdMode = createdMode;
+    }
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/ApplicationValidator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/ApplicationValidator.java
@@ -28,6 +28,9 @@ import org.wso2.carbon.apimgt.migration.validator.utils.Utils;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+/**
+ * The ApplicationValidator class handles all application wise pre validation steps.
+ */
 public class ApplicationValidator {
     private static final Log log = LogFactory.getLog(ApplicationValidator.class);
     protected Utils utils;
@@ -42,25 +45,40 @@ public class ApplicationValidator {
         }
     }
 
+    /**
+     * Validates if an application is using third party kep managers and logs warnings.
+     * <p>
+     * Checks is keys are generated for an application in the AM_APPLICATION_KEY_MAPPING table
+     * and if keys are generated IDN_OAUTH_CONSUMER_APPS table is checked to see if a record exists.
+     * </p>
+     * <p>
+     * If no record exists, a warning is displayed to reconfigure third party key managers for the newest version.
+     * </p>
+     * <p>
+     * Only migrations from 2.x, 3.0.0 and 3.1.0 versions are validated.
+     * </p>
+     *
+     * @param application application to be validated.
+     */
     public void validateAppThirdPartyKMUsage(ApplicationDTO application) {
         Pattern pattern = Pattern.compile("(2\\.\\d\\.\\d)|(3\\.0\\.0)|(3\\.1\\.0)");
         if (pattern.matcher(utils.getMigrateFromVersion()).matches()) {
             log.info("Validating third party key manager usage for application: " + application.getName()
                     + ", subscriber: " + application.getSubscriberId());
-
             Set<ApplicationKeyMappingDTO> applicationKeyMappings = ApiMgtDAO
                     .getInstance()
                     .getKeyMappingFromApplicationId(application.getApplicationId());
             if (!applicationKeyMappings.isEmpty()) {
                 for (ApplicationKeyMappingDTO applicationKeyMapping : applicationKeyMappings) {
-                    boolean isThirdPartyKMUsed = ApiMgtDAO.getInstance()
-                            .isThirdPartyKeyManagerUsed(applicationKeyMapping.getConsumerKey());
+                    boolean isThirdPartyKMUsed = !ApiMgtDAO.getInstance()
+                            .checkIfConsumerAppExists(applicationKeyMapping.getConsumerKey());
                     if (isThirdPartyKMUsed) {
                         log.warn("Usage of third party key manager detected for "
                                 + "application: " + application.getName()
                                 + ", subscriber: " + application.getSubscriberId()
                                 + ", key type: " + applicationKeyMapping.getKeyType()
-                                + ". You may need to reconfigure the third party key manager for latest version"
+                                + ". You may need to reconfigure the third party key manager"
+                                + " with API-M for latest version"
                         );
                     } else {
                         log.info("Third Party key manager usage validation complete for"

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/ApplicationValidator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/ApplicationValidator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.migration.validator.validators;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.migration.util.Constants;
+import org.wso2.carbon.apimgt.migration.validator.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationKeyMappingDTO;
+import org.wso2.carbon.apimgt.migration.validator.utils.Utils;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class ApplicationValidator {
+    private static final Log log = LogFactory.getLog(ApplicationValidator.class);
+    protected Utils utils;
+
+    public ApplicationValidator(Utils utils) {
+        this.utils = utils;
+    }
+
+    public void validate(ApplicationDTO application, String preMigrationStep) {
+        if (Constants.preValidationService.APP_THIRD_PARTY_KM_VALIDATION.equals(preMigrationStep)) {
+            validateAppThirdPartyKMUsage(application);
+        }
+    }
+
+    public void validateAppThirdPartyKMUsage(ApplicationDTO application) {
+        Pattern pattern = Pattern.compile("(2\\.\\d\\.\\d)|(3\\.0\\.0)|(3\\.1\\.0)");
+        if (pattern.matcher(utils.getMigrateFromVersion()).matches()) {
+            log.info("Validating third party key manager usage for application: " + application.getName()
+                    + ", subscriber: " + application.getSubscriberId());
+
+            Set<ApplicationKeyMappingDTO> applicationKeyMappings = ApiMgtDAO
+                    .getInstance()
+                    .getKeyMappingFromApplicationId(application.getApplicationId());
+            if (!applicationKeyMappings.isEmpty()) {
+                for (ApplicationKeyMappingDTO applicationKeyMapping : applicationKeyMappings) {
+                    boolean isThirdPartyKMUsed = ApiMgtDAO.getInstance()
+                            .isThirdPartyKeyManagerUsed(applicationKeyMapping.getConsumerKey());
+                    if (isThirdPartyKMUsed) {
+                        log.warn("Usage of third party key manager detected for "
+                                + "application: " + application.getName()
+                                + ", subscriber: " + application.getSubscriberId()
+                                + ", key type: " + applicationKeyMapping.getKeyType()
+                                + ". You may need to reconfigure the third party key manager for latest version"
+                        );
+                    } else {
+                        log.info("Third Party key manager usage validation complete for"
+                                + " application: " + application.getName()
+                                + ", subscriber: " + application.getSubscriberId()
+                                + ", key type: " + applicationKeyMapping.getKeyType());
+                    }
+                }
+            } else {
+                log.info("Third Party key manager usage validation complete, "
+                        + "Keys are not generated for application: " + application.getName()
+                        + ", subscriber: " + application.getSubscriberId());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Third party key manager interfaces have changes in new versions and may need to be reconfigured.
https://github.com/wso2/api-manager/issues/607#issue-1334421778

## Goals
Warn users about the changes to do necessary configurations.

## Approach
Retrieve all applications and check is keys are generated. If keys are generated check IDN_OAUTH_CONSUMER_APPS by CONSUMER_KEY. If the record is empty then third party key manager is used for the application and a warning is displayed at pre-migration. 

## Test environment
2.6.0 to 4.1.0 migrations were done on MySQL 8.0.30, PostgreSQL 14.6 