### PR TITLE
[4.0.0] Add api resource level auth scheme prevalidation step

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -48,6 +48,7 @@ public class Constants {
         public static final String API_DEFINITION_VALIDATION = "apiDefinitionValidation";
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
+        public static final String API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION = "apiResourceLevelAuthSchemeValidation";
         public static final String SAVE_INVALID_DEFINITION = "saveInvalidDefinition";
     }
 

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
@@ -35,8 +35,11 @@ public class ValidationHandler {
     private String tenantRangeArgs;
     private final String migratedVersion = "4.0.0";
     private String blackListTenantArguments = System.getProperty(Constants.ARG_MIGRATE_BLACKLIST_TENANTS);
-    private final String[] validatorList = {Constants.preValidationService.API_AVAILABILITY_VALIDATION,
-            Constants.preValidationService.API_DEFINITION_VALIDATION};
+    private final String[] validatorList = {
+            Constants.preValidationService.API_AVAILABILITY_VALIDATION,
+            Constants.preValidationService.API_DEFINITION_VALIDATION,
+            Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION,
+    };
     private final Validator validator;
 
     public ValidationHandler(String migrateFromVersion, String preMigrationStep,

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/ApiMgtDAO.java
@@ -1,15 +1,21 @@
 package org.wso2.carbon.apimgt.migration.validator.dao;
 
-import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ApiMgtDAO {
+    private static final Log log = LogFactory.getLog(ApiMgtDAO.class);
     private static ApiMgtDAO INSTANCE = null;
 
     public static ApiMgtDAO getInstance() {
@@ -37,5 +43,38 @@ public class ApiMgtDAO {
             }
         }
         return id;
+    }
+
+    public Set<URITemplate> getURITemplatesByAPIID(int apiId) {
+
+        Set<URITemplate> urlTemplates = new HashSet<>();
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            try (PreparedStatement ps = connection.prepareStatement(SQLConstants.GET_URL_TEMPLATES_BY_API_ID_SQL_260)) {
+                ps.setInt(1, apiId);
+                try (ResultSet resultSet = ps.executeQuery();) {
+                    while (resultSet.next()) {
+                        String script = null;
+                        URITemplate uriTemplate = new URITemplate();
+                        uriTemplate.setUriTemplate(resultSet.getString("URL_PATTERN"));
+                        uriTemplate.setHTTPVerb(resultSet.getString("HTTP_METHOD"));
+                        uriTemplate.setAuthType(resultSet.getString("AUTH_SCHEME"));
+                        uriTemplate.setThrottlingTier(resultSet.getString("THROTTLING_TIER"));
+                        InputStream mediationScriptBlob = resultSet.getBinaryStream("MEDIATION_SCRIPT");
+                        if (mediationScriptBlob != null) {
+                            script = APIMgtDBUtil.getStringFromInputStream(mediationScriptBlob);
+                            if (script.isEmpty()) {
+                                script = null;
+                            }
+                        }
+                        uriTemplate.setMediationScript(script);
+                        urlTemplates.add(uriTemplate);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error on retrieving URLTemplates for apiResourceLevelAuthSchemeValidation validation", e);
+        }
+        return urlTemplates;
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/SQLConstants.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/SQLConstants.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.migration.validator.dao;
+
+public class SQLConstants {
+    public static final String GET_API_ID_SQL =
+            "SELECT     " +
+                    "   API.API_ID " +
+                    " FROM " +
+                    "   AM_API API " +
+                    " WHERE " +
+                    "   API.API_PROVIDER = ? " +
+                    "   AND API.API_NAME = ? " +
+                    "   AND API.API_VERSION = ? ";
+
+    public static final String GET_URL_TEMPLATES_BY_API_ID_SQL_260 =
+            " SELECT " +
+                    "   URL_PATTERN," +
+                    "   HTTP_METHOD," +
+                    "   AUTH_SCHEME," +
+                    "   THROTTLING_TIER, " +
+                    "   MEDIATION_SCRIPT " +
+                    " FROM " +
+                    "   AM_API_URL_MAPPING " +
+                    " WHERE " +
+                    "   API_ID = ? " +
+                    " ORDER BY " +
+                    "   URL_MAPPING_ID ASC ";
+}
+

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V400Validator.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V400Validator.java
@@ -6,9 +6,11 @@ import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIConstants.OASResourceAuthTypes;
 import org.wso2.carbon.apimgt.impl.definitions.AsyncApiParserUtil;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
@@ -27,6 +29,8 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.sql.SQLException;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 public class V400Validator extends Validator {
     private static final Log log = LogFactory.getLog(V400Validator.class);
@@ -124,7 +128,7 @@ public class V400Validator extends Validator {
                     .validateGraphQLSchema("schema.graphql", graphqlSchema);
         } catch (APIManagementException e) {
             log.error(" Error while validating graphql api definition for API:" + apiName
-                    + " version: " +    apiVersion + " " + e);
+                    + " version: " + apiVersion + " " + e);
         }
         if (graphQLValidationResponseDTO != null && !graphQLValidationResponseDTO.isIsValid()) {
             log.error(" Invalid GraphQL definition found. " + "ErrorMessage: " + graphQLValidationResponseDTO
@@ -209,6 +213,34 @@ public class V400Validator extends Validator {
         } else {
             log.info("API " + apiName + " version: " + apiVersion + " type: " + apiType + " was not validated "
                     + "since the AsyncAPI definitions are supported after API Manager 4.0.0");
+        }
+    }
+
+    @Override
+    public void validateApiResourceLevelAuthScheme() {
+
+        Pattern pattern = Pattern.compile("2\\.\\d\\.\\d");
+
+        if (pattern.matcher(utils.getMigrateFromVersion()).matches()) {
+            log.info("Validating Resource Level Auth Scheme of API {name: " + apiName + ", version: " + apiVersion
+                    + ", provider: " + provider + "}");
+            try {
+                int id = ApiMgtDAO.getInstance().getAPIID(provider, apiName, apiVersion);
+                Set<URITemplate> uriTemplates = ApiMgtDAO.getInstance().getURITemplatesByAPIID(id);
+                for (URITemplate uriTemplate : uriTemplates) {
+                    if (!(OASResourceAuthTypes.APPLICATION_OR_APPLICATION_USER.equals(uriTemplate.getAuthType())
+                            || OASResourceAuthTypes.NONE.equals(uriTemplate.getAuthType())
+                            || "Any".equals(uriTemplate.getAuthType()))) {
+                        log.warn("Resource level Authentication Schemes 'Application', 'Application User' are not " +
+                                "supported, Resource {HTTP verb: " + uriTemplate.getHTTPVerb() + ", URL pattern: " +
+                                uriTemplate.getUriTemplate() + ", Auth Scheme: " + uriTemplate.getAuthType() + "}");
+                    }
+                }
+            } catch (SQLException e) {
+                log.error("Error on Retrieving URITemplates for apiResourceLevelAuthSchemeValidation", e);
+            }
+            log.info("Completed Validating Resource Level Auth Scheme of API {name: " + apiName + ", version: "
+                    + apiVersion + ", provider: " + provider + "}");
         }
     }
 }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
@@ -50,6 +50,8 @@ public abstract class Validator {
             validateAPIDefinition();
         } else if (Constants.preValidationService.API_AVAILABILITY_VALIDATION.equals(preMigrationStep)) {
             validateApiAvailability();
+        } else if (Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION.equals(preMigrationStep)) {
+            validateApiResourceLevelAuthScheme();
         }
     }
 
@@ -58,4 +60,6 @@ public abstract class Validator {
     public abstract void validateAPIDefinition();
 
     public abstract void validateApiAvailability();
+
+    public abstract void validateApiResourceLevelAuthScheme();
 }


### PR DESCRIPTION
## Purpose
Add api resource level auth scheme pre-validation step for older 2.x versions as 'Application' & ' Application_User' auth schemes are not supported anymore.
Fixing https://github.com/wso2/api-manager/issues/601

## Approach
Warnings will be displayed for api resources using the unsupported auth schemes