### PR TITLE
[4.x.x] Add Prevalidation step to warn about third party key-manager usage

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -453,6 +453,7 @@ public class Constants {
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
         public static final String API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION = "apiResourceLevelAuthSchemeValidation";
+        public static final String APP_THIRD_PARTY_KM_VALIDATION = "appThirdPartyKMValidation";
         public static final String SAVE_INVALID_DEFINITION = "saveInvalidDefinition";
     }
 

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dao/constants/SQLConstants.java
@@ -41,4 +41,32 @@ public class SQLConstants {
                     "   API_ID = ? " +
                     " ORDER BY " +
                     "   URL_MAPPING_ID ASC ";
+    public static final String GET_ALL_APPLICATIONS =
+            " SELECT " +
+                    "   APP.APPLICATION_ID,   " +
+                    "   APP.NAME,   " +
+                    "   APP.SUBSCRIBER_ID,   " +
+                    "   APP.APPLICATION_STATUS,   " +
+                    "   APP.CREATED_BY,   " +
+                    "   APP.UUID   " +
+                    " FROM " +
+                    "   AM_APPLICATION APP   ";
+    public static final String GET_APPLICATION_KEY_MAPPING_BY_APP_ID_AND_KEY_TYPE =
+            "SELECT " +
+                    "   APP_KM.APPLICATION_ID,  " +
+                    "   APP_KM.CONSUMER_KEY,    " +
+                    "   APP_KM.KEY_TYPE,    " +
+                    "   APP_KM.STATE,   " +
+                    "   APP_KM.CREATE_MODE  " +
+                    " FROM " +
+                    "   AM_APPLICATION_KEY_MAPPING APP_KM   " +
+                    " WHERE " +
+                    "   APP_KM.APPLICATION_ID = ?   ";
+    public static final String GET_IF_IDN_OAUTH_CONSUMER_APP_EXISTS =
+            "SELECT" +
+                    "   1  " +
+                    " FROM " +
+                    "   IDN_OAUTH_CONSUMER_APPS OC_APP  " +
+                    " WHERE " +
+                    "   OC_APP.CONSUMER_KEY = ?";
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationDTO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationDTO.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.migration.validator.dto;
+
+public class ApplicationDTO {
+    private int applicationId;
+    private String name;
+    private String subscriberId;
+    private String status;
+    private String createdBy;
+    private String uuid;
+
+    public int getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(int applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSubscriberId() {
+        return subscriberId;
+    }
+
+    public void setSubscriberId(String subscriberId) {
+        this.subscriberId = subscriberId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationKeyMappingDTO.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/dto/ApplicationKeyMappingDTO.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.migration.validator.dto;
+
+public class ApplicationKeyMappingDTO {
+    private int applicationId;
+    private String consumerKey;
+    private String keyType;
+    private String state;
+    private String createdMode;
+
+    public int getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(int applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getConsumerKey() {
+        return consumerKey;
+    }
+
+    public void setConsumerKey(String consumerKey) {
+        this.consumerKey = consumerKey;
+    }
+
+    public String getKeyType() {
+        return keyType;
+    }
+
+    public void setKeyType(String keyType) {
+        this.keyType = keyType;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getCreatedMode() {
+        return createdMode;
+    }
+
+    public void setCreatedMode(String createdMode) {
+        this.createdMode = createdMode;
+    }
+}

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/ApplicationValidator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/ApplicationValidator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.migration.validator.validators;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.migration.util.Constants;
+import org.wso2.carbon.apimgt.migration.validator.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.migration.validator.dto.ApplicationKeyMappingDTO;
+import org.wso2.carbon.apimgt.migration.validator.utils.Utils;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * The ApplicationValidator class handles all application wise pre validation steps.
+ */
+public class ApplicationValidator {
+    private static final Log log = LogFactory.getLog(ApplicationValidator.class);
+    protected Utils utils;
+
+    public ApplicationValidator(Utils utils) {
+        this.utils = utils;
+    }
+
+    public void validate(ApplicationDTO application, String preMigrationStep) {
+        if (Constants.preValidationService.APP_THIRD_PARTY_KM_VALIDATION.equals(preMigrationStep)) {
+            validateAppThirdPartyKMUsage(application);
+        }
+    }
+
+    /**
+     * Validates if an application is using third party kep managers and logs warnings.
+     * <p>
+     * Checks is keys are generated for an application in the AM_APPLICATION_KEY_MAPPING table
+     * and if keys are generated IDN_OAUTH_CONSUMER_APPS table is checked to see if a record exists.
+     * </p>
+     * <p>
+     * If no record exists, a warning is displayed to reconfigure third party key managers for the newest version.
+     * </p>
+     * <p>
+     * Only migrations from 2.x, 3.0.0 and 3.1.0 versions are validated.
+     * </p>
+     *
+     * @param application application to be validated.
+     */
+    public void validateAppThirdPartyKMUsage(ApplicationDTO application) {
+        Pattern pattern = Pattern.compile("(2\\.\\d\\.\\d)|(3\\.0\\.0)|(3\\.1\\.0)");
+        if (pattern.matcher(utils.getMigrateFromVersion()).matches()) {
+            log.info("Validating third party key manager usage for application: " + application.getName()
+                    + ", subscriber: " + application.getSubscriberId());
+            Set<ApplicationKeyMappingDTO> applicationKeyMappings = ApiMgtDAO
+                    .getInstance()
+                    .getKeyMappingFromApplicationId(application.getApplicationId());
+            if (!applicationKeyMappings.isEmpty()) {
+                for (ApplicationKeyMappingDTO applicationKeyMapping : applicationKeyMappings) {
+                    boolean isThirdPartyKMUsed = !ApiMgtDAO.getInstance()
+                            .checkIfConsumerAppExists(applicationKeyMapping.getConsumerKey());
+                    if (isThirdPartyKMUsed) {
+                        log.warn("Usage of third party key manager detected for "
+                                + "application: " + application.getName()
+                                + ", subscriber: " + application.getSubscriberId()
+                                + ", key type: " + applicationKeyMapping.getKeyType()
+                                + ". You may need to reconfigure the third party key manager"
+                                + " with API-M for latest version"
+                        );
+                    } else {
+                        log.info("Third Party key manager usage validation complete for"
+                                + " application: " + application.getName()
+                                + ", subscriber: " + application.getSubscriberId()
+                                + ", key type: " + applicationKeyMapping.getKeyType());
+                    }
+                }
+            } else {
+                log.info("Third Party key manager usage validation complete, "
+                        + "Keys are not generated for application: " + application.getName()
+                        + ", subscriber: " + application.getSubscriberId());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Third party key manager interfaces have changes in new versions and may need to be reconfigured.
Fixing https://github.com/wso2/api-manager/issues/607#issue-1334421778

## Goals
Warn users about the changes to do necessary configurations.

## Approach
Retrieve all applications and check is keys are generated. If keys are generated check IDN_OAUTH_CONSUMER_APPS by CONSUMER_KEY. If the record is empty then third party key manager is used for the application and a warning is displayed at pre-migration. 