### PR TITLE
[4.x.x] Skip revision deployment if no gateway env ('none') is configured

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v400/V400RegistryResourceMigrator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/v400/V400RegistryResourceMigrator.java
@@ -401,16 +401,20 @@ public class V400RegistryResourceMigrator extends RegistryResourceMigrator {
                             List<APIRevisionDeployment> apiRevisionDeployments = new ArrayList<>();
                             String environments = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_ENVIRONMENTS);
                             String[] arrOfEnvironments = environments.split(",");
-                            for (String environment : arrOfEnvironments) {
-                                APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
-                                apiRevisionDeployment.setRevisionUUID(revisionId);
-                                apiRevisionDeployment.setDeployment(environment);
-                                // Null VHost for the environments defined in deployment.toml (the default vhost)
-                                apiRevisionDeployment.setVhost(null);
-                                apiRevisionDeployment.setDisplayOnDevportal(true);
-                                apiRevisionDeployments.add(apiRevisionDeployment);
+                            if ("none".equals(environments)) {
+                                log.info("WSO2 API-M Migration Task : No gateway environments are configured for API " +
+                                        apiInfoDTO.getUuid() + ". Hence revision deployment is skipped.");
+                            } else {
+                                for (String environment : arrOfEnvironments) {
+                                    APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
+                                    apiRevisionDeployment.setRevisionUUID(revisionId);
+                                    apiRevisionDeployment.setDeployment(environment);
+                                    // Null VHost for the environments defined in deployment.toml (the default vhost)
+                                    apiRevisionDeployment.setVhost(null);
+                                    apiRevisionDeployment.setDisplayOnDevportal(true);
+                                    apiRevisionDeployments.add(apiRevisionDeployment);
+                                }
                             }
-
                             String[] labels = apiArtifact.getAttributes(APIConstants.API_LABELS_GATEWAY_LABELS);
                             if (labels != null) {
                                 for (String label : labels) {


### PR DESCRIPTION
## Purpose
Issue - an error is displayed when api is visited on publisher portal after migration, when the gateway environment of the published API is configured as 'none' 

fixing https://github.com/wso2/api-manager/issues/706

## Approach
Skips revision deployment when the gateway is configured as 'none'