### PR TITLE
[4.x.x] Add pre-validation step to validate api deployed gateway type is not 'none'

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/util/Constants.java
@@ -453,6 +453,7 @@ public class Constants {
         public static final String API_ENDPOINT_VALIDATION = "apiEndpointValidation";
         public static final String API_AVAILABILITY_VALIDATION = "apiAvailabilityValidation";
         public static final String API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION = "apiResourceLevelAuthSchemeValidation";
+        public static final String API_DEPLOYED_GATEWAY_TYPE_VALIDATION = "apiDeployedGatewayTypeValidation";
         public static final String APP_THIRD_PARTY_KM_VALIDATION = "appThirdPartyKMValidation";
         public static final String SAVE_INVALID_DEFINITION = "saveInvalidDefinition";
     }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/ValidationHandler.java
@@ -59,6 +59,7 @@ public class ValidationHandler {
             Constants.preValidationService.API_AVAILABILITY_VALIDATION,
             Constants.preValidationService.API_DEFINITION_VALIDATION,
             Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION,
+            Constants.preValidationService.API_DEPLOYED_GATEWAY_TYPE_VALIDATION,
     };
     private final String[] applicationValidatorList = {
             Constants.preValidationService.APP_THIRD_PARTY_KM_VALIDATION,

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V410Validator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/V410Validator.java
@@ -19,6 +19,7 @@ import org.wso2.carbon.apimgt.migration.validator.utils.Utils;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.PublisherCommonUtils;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLValidationResponseDTO;
 import org.wso2.carbon.governance.api.exception.GovernanceException;
+import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
 import org.wso2.carbon.governance.api.util.GovernanceUtils;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -245,4 +246,21 @@ public class V410Validator extends Validator {
 
     }
 
+    @Override
+    public void validateApiDeployedGatewayType(GenericArtifact apiArtifact) {
+        log.info("Validating deployed gateway type for API {name: " + apiName + ", version: " + apiVersion
+                + ", provider: " + provider + "}");
+        try {
+            String environments = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_ENVIRONMENTS);
+            if ("none".equals(environments)) {
+                log.warn("No gateway environments are configured for API {name: " + apiName + ", version: " + apiVersion
+                        + ", provider: " + provider + "}. Hence revision deployment will be skipped at migration");
+            }
+            log.info("Completed deployed gateway type validation for API {name: " + apiName + ", version: " + apiVersion
+                    + ", provider: " + provider + "}");
+        } catch (GovernanceException e) {
+            log.error("Error on retrieving API Gateway environment from API generic artifact", e);
+        }
+
+    }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/validator/validators/Validator.java
@@ -52,6 +52,8 @@ public abstract class Validator {
             validateApiAvailability();
         } else if (Constants.preValidationService.API_RESOURCE_LEVEL_AUTH_SCHEME_VALIDATION.equals(preMigrationStep)) {
             validateApiResourceLevelAuthScheme();
+        } else if (Constants.preValidationService.API_DEPLOYED_GATEWAY_TYPE_VALIDATION.equals(preMigrationStep)) {
+            validateApiDeployedGatewayType(artifact);
         }
     }
 
@@ -63,4 +65,5 @@ public abstract class Validator {
 
     public abstract void validateApiResourceLevelAuthScheme();
 
+    public abstract void validateApiDeployedGatewayType(GenericArtifact apiArtifact);
 }


### PR DESCRIPTION
## Purpose
If deployed gateway of an api is 'none' it gives an error after migration in the publisher portal.
Issue : https://github.com/wso2/api-manager/issues/706
It was fixed by skipping revision deployment for such APIs
Fix: #277 
This pre-validator warns the user while migration, about APIs with gateway type set to none.
Fixing : https://github.com/wso2/api-manager/issues/747

## Approach
Warn the user that API revision deployment will be skipped, if the gateway environment type of the API is set to 'none'.

## Related PRs
#277
