### PR TITLE
[4.0.0] Modify exception handling to continue migration on errors

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
@@ -196,8 +196,8 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
             String version = apiInfoDTO.getApiVersion();
             for (APIURLMappingInfoDTO apiurlMappingInfoDTO : urlMappingData) {
                 if (apiurlMappingInfoDTO.getApiId() == apiInfoDTO.getApiId()) {
-                    String resourcePath = context + "/" + version + apiurlMappingInfoDTO.getUrlPattern() + ":" +
-                            apiurlMappingInfoDTO.getHttpMethod();
+                    String resourcePath = context + "/" + version + apiurlMappingInfoDTO.getUrlPattern() + ":"
+                            + apiurlMappingInfoDTO.getHttpMethod();
                     int urlMappingId = apiurlMappingInfoDTO.getUrlMappingId();
                     int scopeId = apiMgtDAO.getScopeId(resourcePath);
                     if (scopeId != -1) {
@@ -245,8 +245,8 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
         for (Tenant tenant : getTenantsArray()) {
             try {
                 registryService.startTenantFlow(tenant);
-                log.info("WSO2 API-M Migration Task : Updating APIs for tenant " + tenant.getId() + '(' +
-                        tenant.getDomain() + ')');
+                log.info("WSO2 API-M Migration Task : Updating APIs for tenant " + tenant.getId() + '('
+                        + tenant.getDomain() + ')');
                 GenericArtifact[] artifacts = registryService.getGenericAPIArtifacts();
                 for (GenericArtifact artifact : artifacts) {
                     String path = artifact.getPath();
@@ -277,8 +277,8 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
         boolean isError = false;
         for (Tenant tenant : getTenantsArray()) {
             registryService.startTenantFlow(tenant);
-            log.info("WSO2 API-M Migration Task : Updating API properties for tenant " + tenant.getId() +
-                    '(' + tenant.getDomain() + ')');
+            log.info("WSO2 API-M Migration Task : Updating API properties for tenant " + tenant.getId()
+                    + '(' + tenant.getDomain() + ')');
             GenericArtifact[] artifacts = registryService.getGenericAPIArtifacts();
             for (GenericArtifact artifact : artifacts) {
                 try {
@@ -291,12 +291,12 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
                         registryService.updateAPIPropertyVisibility(path);
                     }
                 } catch (GovernanceException e) {
-                    log.error("WSO2 API-M Migration Task : Error while accessing API artifact " +
-                            "in registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Error while accessing API artifact "
+                            + "in registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                 } catch (RegistryException | UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while updating API artifact " +
-                            "in the registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Error while updating API artifact "
+                            + "in the registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                 }
             }
@@ -324,8 +324,8 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
         try {
             List<Tenant> tenants = APIUtil.getAllTenantsWithSuperTenant();
             for (Tenant tenant : tenants) {
-                log.info("WSO2 API-M Migration Task : Started updating API Type in DB " +
-                        "for tenant: " + tenant.getDomain());
+                log.info("WSO2 API-M Migration Task : Started updating API Type in DB "
+                        + "for tenant: " + tenant.getDomain());
                 List<APIInfoDTO> apiInfoDTOList = new ArrayList<>();
                 try {
                     int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
@@ -351,9 +351,9 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
                                 apiInfoDTO.setType(artifact.getAttribute("overview_type"));
                                 apiInfoDTOList.add(apiInfoDTO);
                             } catch (GovernanceException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "fetching attributes from artifact, artifact path: " +
-                                        ((GenericArtifactImpl) artifact).getArtifactPath(), e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "fetching attributes from artifact, artifact path: "
+                                        + ((GenericArtifactImpl) artifact).getArtifactPath(), e);
                                 isError = true;
                             }
                         }
@@ -361,20 +361,20 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
                         apiMgtDAO.updateAPIType(apiInfoDTOList, tenant.getId(), tenant.getDomain());
                     }
                 } catch (RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initiation the registry, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while initiation the registry, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (APIManagementException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving API artifact, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving API artifact, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (APIMigrationException e) {
-                    log.error("WSO2 API-M Migration Task : Error while updating API type, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while updating API type, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
@@ -385,8 +385,8 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
             isError = true;
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during " +
-                    "updating API Type in DB for all tenants");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during "
+                    + "updating API Type in DB for all tenants");
         } else {
             log.info("WSO2 API-M Migration Task : Completed updating API Type in DB for all tenants");
         }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -97,10 +97,12 @@ import java.util.Set;
 import java.util.UUID;
 import com.google.gson.Gson;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -191,110 +193,154 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
     }
 
     public void updateRegistryPathsOfIconAndWSDL() throws APIMigrationException {
+        boolean isError = false;
+        log.info("WSO2 API-M Migration Task : Updating registry paths of API icons and WSDL for al tenants");
         try {
             List<Tenant> tenants = APIUtil.getAllTenantsWithSuperTenant();
             for (Tenant tenant : tenants) {
                 log.info("WSO2 API-M Migration Task : Updating Registry paths of API icons and WSDLs of "
                         + "tenant " + + tenant.getId() + '(' + tenant.getDomain() + ')');
-                List<APIInfoDTO> apiInfoDTOList = new ArrayList<>();
-                int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
-                APIUtil.loadTenantRegistry(apiTenantId);
-                startTenantFlow(tenant.getDomain(), apiTenantId,
-                        MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
-                this.registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(apiTenantId);
-                GenericArtifactManager tenantArtifactManager = APIUtil.getArtifactManager(this.registry,
-                        APIConstants.API_KEY);
-                if (tenantArtifactManager != null) {
-                    GenericArtifact[] tenantArtifacts = tenantArtifactManager.getAllGenericArtifacts();
-                    for (GenericArtifact artifact : tenantArtifacts) {
-                        API api = APIUtil.getAPI(artifact);
-                        if (api != null) {
-                            APIInfoDTO apiInfoDTO = new APIInfoDTO();
-                            apiInfoDTO.setUuid(api.getUUID());
-                            apiInfoDTO.setApiProvider(APIUtil.replaceEmailDomainBack(api.getId().getProviderName()));
-                            apiInfoDTO.setApiName(api.getId().getApiName());
-                            apiInfoDTO.setApiVersion(api.getId().getVersion());
-                            apiInfoDTOList.add(apiInfoDTO);
-                        }
-                    }
-                    for (APIInfoDTO apiInfoDTO : apiInfoDTOList) {
-                        String apiPath = GovernanceUtils.getArtifactPath(registry, apiInfoDTO.getUuid());
-                        int prependIndex = apiPath.lastIndexOf("/api");
-                        String artifactPath = apiPath.substring(0, prependIndex);
-                        String artifactOldPathIcon = APIConstants.API_IMAGE_LOCATION + RegistryConstants.PATH_SEPARATOR
-                                + apiInfoDTO.getApiProvider() + RegistryConstants.PATH_SEPARATOR + apiInfoDTO.getApiName()
-                                + RegistryConstants.PATH_SEPARATOR + apiInfoDTO.getApiVersion()
-                                + RegistryConstants.PATH_SEPARATOR + APIConstants.API_ICON_IMAGE;
-                        if (registry.resourceExists(artifactOldPathIcon)) {
-                            Resource resource = registry.get(artifactOldPathIcon);
-                            String thumbPath = artifactPath + RegistryConstants.PATH_SEPARATOR
-                                    + APIConstants.API_ICON_IMAGE;
-                            registry.put(thumbPath, resource);
-                            GenericArtifact apiArtifact = tenantArtifactManager.getGenericArtifact(apiInfoDTO.getUuid());
-                            apiArtifact.setAttribute(APIConstants.API_OVERVIEW_THUMBNAIL_URL, thumbPath);
-                            tenantArtifactManager.updateGenericArtifact(apiArtifact);
-                        }
-                        startTenantFlow(tenant.getDomain(), apiTenantId,
-                                MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
-                        String wsdlResourcePathOld = APIConstants.API_WSDL_RESOURCE_LOCATION
-                                + RegistryPersistenceUtil.createWsdlFileName(
-                                        RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider()),
-                                apiInfoDTO.getApiName(), apiInfoDTO.getApiVersion());
-                        APIIdentifier identifier = new APIIdentifier(
-                                RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider()),
-                                apiInfoDTO.getApiName(), apiInfoDTO.getApiVersion());
-                        String wsdlResourceArchivePathOld = RegistryPersistenceUtil.getWsdlArchivePath(identifier);
-                        String resourcePath = null;
-                        if (registry.resourceExists(wsdlResourcePathOld)) {
-                            resourcePath = wsdlResourcePathOld;
-                        } else if (registry.resourceExists(wsdlResourceArchivePathOld)) {
-                            resourcePath = wsdlResourceArchivePathOld;
-                        }
-                        if (resourcePath != null) {
-                            log.info("WSDL resource path: " + resourcePath);
-                            Resource resource = registry.get(resourcePath);
-                            String wsdlResourcePath;
-                            String wsdlResourcePathArchive = artifactPath + RegistryConstants.PATH_SEPARATOR
-                                    + APIConstants.API_WSDL_ARCHIVE_LOCATION
-                                    + RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider())
-                                    + APIConstants.WSDL_PROVIDER_SEPERATOR + apiInfoDTO.getApiName()
-                                    + apiInfoDTO.getApiVersion() + APIConstants.ZIP_FILE_EXTENSION;
-                            String wsdlResourcePathFile = artifactPath + RegistryConstants.PATH_SEPARATOR
-                                    + RegistryPersistenceUtil.createWsdlFileName(
-                                            RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider()),
-                                    apiInfoDTO.getApiName(), apiInfoDTO.getApiVersion());
-                            if (resource.getPath() != null
-                                    && resource.getPath().endsWith(APIConstants.ZIP_FILE_EXTENSION)) {
-                                wsdlResourcePath = wsdlResourcePathArchive;
-                                if ("application/octet-stream".equals(resource.getMediaType())) {
-                                    resource.setMediaType(APIConstants.APPLICATION_ZIP);
-                                    registry.put(resourcePath, resource);
+                try {
+                    List<APIInfoDTO> apiInfoDTOList = new ArrayList<>();
+                    int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
+                    APIUtil.loadTenantRegistry(apiTenantId);
+                    startTenantFlow(tenant.getDomain(), apiTenantId,
+                            MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
+                    this.registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(apiTenantId);
+                    GenericArtifactManager tenantArtifactManager = APIUtil.getArtifactManager(this.registry,
+                            APIConstants.API_KEY);
+                    if (tenantArtifactManager != null) {
+                        GenericArtifact[] tenantArtifacts = tenantArtifactManager.getAllGenericArtifacts();
+                        for (GenericArtifact artifact : tenantArtifacts) {
+                            try {
+                                API api = APIUtil.getAPI(artifact);
+                                if (api != null) {
+                                    APIInfoDTO apiInfoDTO = new APIInfoDTO();
+                                    apiInfoDTO.setUuid(api.getUUID());
+                                    apiInfoDTO.setApiProvider(APIUtil.replaceEmailDomainBack(api.getId().getProviderName()));
+                                    apiInfoDTO.setApiName(api.getId().getApiName());
+                                    apiInfoDTO.setApiVersion(api.getId().getVersion());
+                                    apiInfoDTOList.add(apiInfoDTO);
                                 }
-                            } else {
-                                wsdlResourcePath = wsdlResourcePathFile;
+                            } catch (APIManagementException e) {
+                                log.error("WSO2 API-M Migration Task : Error while getting API from APIUtil", e);
+                                isError = true;
                             }
-                            registry.copy(resourcePath, wsdlResourcePath);
-                            GenericArtifact apiArtifact = tenantArtifactManager.getGenericArtifact(apiInfoDTO.getUuid());
-                            String absoluteWSDLResourcePath = RegistryUtils
-                                    .getAbsolutePath(RegistryContext.getBaseInstance(),
-                                            RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH) + wsdlResourcePath;
-                            String wsdlRegistryPath = RegistryConstants.PATH_SEPARATOR + "registry" +
-                                    RegistryConstants.PATH_SEPARATOR + "resource" + absoluteWSDLResourcePath;
-                            apiArtifact.setAttribute(APIConstants.API_OVERVIEW_WSDL, wsdlRegistryPath);
-                            tenantArtifactManager.updateGenericArtifact(apiArtifact);
+                        }
+                        for (APIInfoDTO apiInfoDTO : apiInfoDTOList) {
+                            try {
+                                String apiPath = GovernanceUtils.getArtifactPath(registry, apiInfoDTO.getUuid());
+                                int prependIndex = apiPath.lastIndexOf("/api");
+                                String artifactPath = apiPath.substring(0, prependIndex);
+                                String artifactOldPathIcon = APIConstants.API_IMAGE_LOCATION + RegistryConstants.PATH_SEPARATOR
+                                        + apiInfoDTO.getApiProvider() + RegistryConstants.PATH_SEPARATOR + apiInfoDTO.getApiName()
+                                        + RegistryConstants.PATH_SEPARATOR + apiInfoDTO.getApiVersion()
+                                        + RegistryConstants.PATH_SEPARATOR + APIConstants.API_ICON_IMAGE;
+                                if (registry.resourceExists(artifactOldPathIcon)) {
+                                    Resource resource = registry.get(artifactOldPathIcon);
+                                    String thumbPath = artifactPath + RegistryConstants.PATH_SEPARATOR
+                                            + APIConstants.API_ICON_IMAGE;
+                                    registry.put(thumbPath, resource);
+                                    GenericArtifact apiArtifact = tenantArtifactManager.getGenericArtifact(apiInfoDTO.getUuid());
+                                    apiArtifact.setAttribute(APIConstants.API_OVERVIEW_THUMBNAIL_URL, thumbPath);
+                                    tenantArtifactManager.updateGenericArtifact(apiArtifact);
+                                }
+                                startTenantFlow(tenant.getDomain(), apiTenantId,
+                                        MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
+                                String wsdlResourcePathOld = APIConstants.API_WSDL_RESOURCE_LOCATION
+                                        + RegistryPersistenceUtil.createWsdlFileName(
+                                        RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider()),
+                                        apiInfoDTO.getApiName(), apiInfoDTO.getApiVersion());
+                                APIIdentifier identifier = new APIIdentifier(
+                                        RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider()),
+                                        apiInfoDTO.getApiName(), apiInfoDTO.getApiVersion());
+                                String wsdlResourceArchivePathOld = RegistryPersistenceUtil.getWsdlArchivePath(identifier);
+                                String resourcePath = null;
+                                if (registry.resourceExists(wsdlResourcePathOld)) {
+                                    resourcePath = wsdlResourcePathOld;
+                                } else if (registry.resourceExists(wsdlResourceArchivePathOld)) {
+                                    resourcePath = wsdlResourceArchivePathOld;
+                                }
+                                if (resourcePath != null) {
+                                    log.info("WSDL resource path: " + resourcePath);
+                                    Resource resource = registry.get(resourcePath);
+                                    String wsdlResourcePath;
+                                    String wsdlResourcePathArchive = artifactPath + RegistryConstants.PATH_SEPARATOR
+                                            + APIConstants.API_WSDL_ARCHIVE_LOCATION
+                                            + RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider())
+                                            + APIConstants.WSDL_PROVIDER_SEPERATOR + apiInfoDTO.getApiName()
+                                            + apiInfoDTO.getApiVersion() + APIConstants.ZIP_FILE_EXTENSION;
+                                    String wsdlResourcePathFile = artifactPath + RegistryConstants.PATH_SEPARATOR
+                                            + RegistryPersistenceUtil.createWsdlFileName(
+                                            RegistryPersistenceUtil.replaceEmailDomain(apiInfoDTO.getApiProvider()),
+                                            apiInfoDTO.getApiName(), apiInfoDTO.getApiVersion());
+                                    if (resource.getPath() != null
+                                            && resource.getPath().endsWith(APIConstants.ZIP_FILE_EXTENSION)) {
+                                        wsdlResourcePath = wsdlResourcePathArchive;
+                                        if ("application/octet-stream".equals(resource.getMediaType())) {
+                                            resource.setMediaType(APIConstants.APPLICATION_ZIP);
+                                            registry.put(resourcePath, resource);
+                                        }
+                                    } else {
+                                        wsdlResourcePath = wsdlResourcePathFile;
+                                    }
+                                    registry.copy(resourcePath, wsdlResourcePath);
+                                    GenericArtifact apiArtifact = tenantArtifactManager.getGenericArtifact(apiInfoDTO.getUuid());
+                                    String absoluteWSDLResourcePath = RegistryUtils
+                                            .getAbsolutePath(RegistryContext.getBaseInstance(),
+                                                    RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH) + wsdlResourcePath;
+                                    String wsdlRegistryPath = RegistryConstants.PATH_SEPARATOR + "registry" +
+                                            RegistryConstants.PATH_SEPARATOR + "resource" + absoluteWSDLResourcePath;
+                                    apiArtifact.setAttribute(APIConstants.API_OVERVIEW_WSDL, wsdlRegistryPath);
+                                    tenantArtifactManager.updateGenericArtifact(apiArtifact);
+                                }
+                            } catch (GovernanceException e) {
+                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-" +
+                                        apiInfoDTO.getApiVersion();
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "getting/setting attributes in artifact, apiId: " + apiId, e);
+                                isError = true;
+                            } catch (APIManagementException e) {
+                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-" +
+                                        apiInfoDTO.getApiVersion();
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "getting tenant Admin User name from APIUtil, apiId: " + apiId, e);
+                                isError = true;
+                            } catch (RegistryException e) {
+                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-" +
+                                        apiInfoDTO.getApiVersion();
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "accessing the registry, apiId: " + apiId, e);
+                                isError = true;
+                            }
                         }
                     }
+                } catch (RegistryException e) {
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } catch (UserStoreException e) {
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } catch (APIManagementException e) {
+                    log.error("WSO2 API-M Migration Task : Error while Retrieving API artifact from the registry, " +
+                            "tenant domain: " + tenant.getDomain(), e);
+                    isError = true;
+                } finally {
+                    PrivilegedCarbonContext.endTenantFlow();
                 }
-                PrivilegedCarbonContext.endTenantFlow();
             }
-        } catch (RegistryException e) {
-            log.error("WSO2 API-M Migration Task : Error while initializing the registry", e);
         } catch (UserStoreException e) {
             log.error("WSO2 API-M Migration Task : Error while retrieving the tenants", e);
-        } catch (APIManagementException e) {
-            log.error("WSO2 API-M Migration Task : Error while Retrieving API artifact from the registry", e);
+            isError = true;
         }
-        log.info("WSO2 API-M Migration Task : Updated Registry paths of API icons and WSDLs of all tenants");
+        if (isError) {
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while " +
+                    "updating registry paths of API icons and WSDLs");
+        } else {
+            log.info("WSO2 API-M Migration Task : Completed updating registry paths of API icons and WSDL for all tenants");
+        }
     }
 
     public void apiRevisionRelatedMigration() throws APIMigrationException {
@@ -513,10 +559,10 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(username);
     }
 
-    public void migrateEndpointCertificates() {
+    public void migrateEndpointCertificates() throws APIMigrationException {
         boolean isError = false;
+        log.info("WSO2 API-M Migration Task : Started Migrating Endpoint Certificates");
         File trustStoreFile = new File(TRUST_STORE);
-
         try {
             KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
             try (InputStream localTrustStoreStream = new FileInputStream(trustStoreFile)) {
@@ -526,18 +572,28 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
             Map<String, String> certificateMap = new HashMap<>();
             if (aliases != null) {
                 for (String alias : aliases) {
-                    Certificate certificate = trustStore.getCertificate(alias);
-                    if (certificate != null) {
-                        byte[] encoded = Base64.encodeBase64(certificate.getEncoded());
-                        String base64EncodedString = BEGIN_CERTIFICATE_STRING.concat(new String(encoded)).concat("\n")
-                                .concat(END_CERTIFICATE_STRING);
-                        base64EncodedString = Base64.encodeBase64URLSafeString(base64EncodedString.getBytes());
-                        certificateMap.put(alias, base64EncodedString);
-                        log.info("WSO2 API-M Migration Task : Adding encoded certificate content of alias: " + alias
-                                + " to DB");
-                    } else {
-                        log.error("WSO2 API-M Migration Task : Error while retrieving endpoint certificate for" +
-                                " alias: " + alias + ". The certificate does not exist in the trust store.");
+                    try {
+                        Certificate certificate = trustStore.getCertificate(alias);
+                        if (certificate != null) {
+                            byte[] encoded = Base64.encodeBase64(certificate.getEncoded());
+                            String base64EncodedString = BEGIN_CERTIFICATE_STRING.concat(new String(encoded)).concat("\n")
+                                    .concat(END_CERTIFICATE_STRING);
+                            base64EncodedString = Base64.encodeBase64URLSafeString(base64EncodedString.getBytes());
+                            certificateMap.put(alias, base64EncodedString);
+                            log.info("WSO2 API-M Migration Task : Adding encoded certificate content of alias: " + alias
+                                    + " to DB");
+                        } else {
+                            log.error("WSO2 API-M Migration Task : Error while retrieving endpoint certificate for" +
+                                    " alias: " + alias + ". The certificate does not exist in the trust store.");
+                            isError = true;
+                        }
+                    } catch (KeyStoreException e) {
+                        log.error("WSO2 API-M Migration Task : Error while " +
+                                "getting certificate from trust store for alias: " + alias, e);
+                        isError = true;
+                    } catch (CertificateException e) {
+                        log.error("WSO2 API-M Migration Task : Error while " +
+                                "encoding certificate for alias: " + alias, e);
                         isError = true;
                     }
                 }
@@ -545,13 +601,16 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                 log.info("WSO2 API-M Migration Task : No endpoint certificates defined");
             }
             APIMgtDAO.getInstance().updateEndpointCertificates(certificateMap);
-            if (isError) {
-                throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during Endpoint " +
-                        "Certificate Migration, hence could not migrate certificates for some artifacts.");
-            }
         } catch (NoSuchAlgorithmException | IOException | CertificateException
-                | KeyStoreException | APIMigrationException e) {
+                 | KeyStoreException | APIMigrationException e) {
             log.error("WSO2 API-M Migration Task : Error while Migrating Endpoint Certificates", e);
+            isError = true;
+        }
+        if (isError) {
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during Endpoint " +
+                    "Certificate Migration, hence could not migrate certificates for some artifacts.");
+        } else {
+            log.info("WSO2 API-M Migration Task : Completed Migrating Endpoint Certificates");
         }
     }
 
@@ -639,135 +698,214 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
         }
     }
 
-    public void migrateWebSocketAPI() {
+    public void migrateWebSocketAPI() throws APIMigrationException {
+        boolean isError = false;
+        log.info("WSO2 API-M Migration Task : Migrating WebSocket APIs for all tenants");
         try {
             // migrate registry artifacts
             List<Integer> wsAPIs = new ArrayList<>();
             List<Tenant> tenants = APIUtil.getAllTenantsWithSuperTenant();
             Map<String, String> wsUriMapping = new HashMap<>();
             for (Tenant tenant : tenants) {
-                int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
-                APIUtil.loadTenantRegistry(apiTenantId);
-                startTenantFlow(tenant.getDomain(), apiTenantId,
-                        MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
-                this.registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(apiTenantId);
-                GenericArtifactManager tenantArtifactManager = APIUtil.getArtifactManager(this.registry,
-                        APIConstants.API_KEY);
-                if (tenantArtifactManager != null) {
-                    GenericArtifact[] tenantArtifacts = tenantArtifactManager.getAllGenericArtifacts();
-                    for (GenericArtifact artifact : tenantArtifacts) {
-                        if (StringUtils.equalsIgnoreCase(artifact.getAttribute(APIConstants.API_OVERVIEW_TYPE),
-                                APIConstants.APITransportType.WS.toString())) {
-                            int id = Integer.parseInt(APIMgtDAO.getInstance().getAPIID(
-                                    artifact.getAttribute(Constants.API_OVERVIEW_CONTEXT)));
-                            wsAPIs.add(id);
-                            artifact.setAttribute(APIConstants.API_OVERVIEW_WS_URI_MAPPING,
-                                    new Gson().toJson(wsUriMapping));
-                            tenantArtifactManager.updateGenericArtifact(artifact);
+                try {
+                    int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
+                    APIUtil.loadTenantRegistry(apiTenantId);
+                    startTenantFlow(tenant.getDomain(), apiTenantId,
+                            MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
+                    this.registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(apiTenantId);
+                    GenericArtifactManager tenantArtifactManager = APIUtil.getArtifactManager(this.registry,
+                            APIConstants.API_KEY);
+                    if (tenantArtifactManager != null) {
+                        GenericArtifact[] tenantArtifacts = tenantArtifactManager.getAllGenericArtifacts();
+                        for (GenericArtifact artifact : tenantArtifacts) {
+                            try {
+                                if (StringUtils.equalsIgnoreCase(artifact.getAttribute(APIConstants.API_OVERVIEW_TYPE),
+                                        APIConstants.APITransportType.WS.toString())) {
+                                    int id = Integer.parseInt(APIMgtDAO.getInstance().getAPIID(
+                                            artifact.getAttribute(Constants.API_OVERVIEW_CONTEXT)));
+                                    wsAPIs.add(id);
+                                    artifact.setAttribute(APIConstants.API_OVERVIEW_WS_URI_MAPPING,
+                                            new Gson().toJson(wsUriMapping));
+                                    tenantArtifactManager.updateGenericArtifact(artifact);
 
-                            API api = APIUtil.getAPI(artifact);
-                            if (api != null) {
+                                    API api = APIUtil.getAPI(artifact);
+                                    if (api != null) {
 
-                                AsyncApiParser asyncApiParser = new AsyncApiParser();
-                                String apiDefinition = asyncApiParser.generateAsyncAPIDefinition(api);
-                                APIProvider apiProviderTenant = APIManagerFactory.getInstance().getAPIProvider(
-                                        APIUtil.getTenantAdminUserName(tenant.getDomain()));
-                                apiProviderTenant.saveAsyncApiDefinition(api, apiDefinition);
-                            } else {
-                                log.error("WSO2 API-M Migration Task : Async Api definition is not added for the API " +
-                                        artifact.getAttribute(org.wso2.carbon.apimgt.impl.APIConstants.API_OVERVIEW_NAME)
-                                        + " due to returned API is null");
+                                        AsyncApiParser asyncApiParser = new AsyncApiParser();
+                                        String apiDefinition = asyncApiParser.generateAsyncAPIDefinition(api);
+                                        APIProvider apiProviderTenant = APIManagerFactory.getInstance().getAPIProvider(
+                                                APIUtil.getTenantAdminUserName(tenant.getDomain()));
+                                        apiProviderTenant.saveAsyncApiDefinition(api, apiDefinition);
+                                    } else {
+                                        log.error("WSO2 API-M Migration Task : Async Api definition is not added for the API " +
+                                                artifact.getAttribute(Constants.API_OVERVIEW_NAME)
+                                                + " due to returned API is null");
+                                        isError = true;
+                                    }
+                                }
+                            } catch (GovernanceException e) {
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "fetching attributes from artifact, artifact path: ", e);
+                                isError = true;
+                            } catch (APIManagementException e) {
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "generating/saving Async API Definition, artifact path: ", e);
+                                isError = true;
+                            } catch (APIMigrationException e) {
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "accessing ApiMgtDAO for migrating WebSocket APIs, artifact path: ", e);
+                                isError = true;
                             }
                         }
                     }
+                } catch (RegistryException e) {
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } catch (UserStoreException e) {
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } catch (APIManagementException e) {
+                    log.error("WSO2 API-M Migration Task : Error while accessing APIUtil " +
+                            "for migrating WebSocket APIs, tenant domain: " + tenant.getDomain(), e);
+                    isError = true;
+                } finally {
+                    PrivilegedCarbonContext.endTenantFlow();
                 }
-                PrivilegedCarbonContext.endTenantFlow();
             }
             // Remove previous entries(In 3.x we are setting default REST methods with /*)
             apiMgtDAO.removePreviousURLTemplatesForWSAPIs(wsAPIs);
             //  add default url templates
             apiMgtDAO.addDefaultURLTemplatesForWSAPIs(wsAPIs);
-        } catch (RegistryException e) {
-            log.error("WSO2 API-M Migration Task : Error while initializing the registry", e);
         } catch (UserStoreException e) {
             log.error("WSO2 API-M Migration Task : Error while retrieving the tenants", e);
-        } catch (APIManagementException e) {
-            log.error("WSO2 API-M Migration Task : Error while Retrieving API artifact from the registry", e);
+            isError = true;
         } catch (APIMigrationException e) {
-            log.error("WSO2 API-M Migration Task : Error while migrating WebSocket APIs", e);
+            log.error("WSO2 API-M Migration Task : Error while removing/adding url templates for WebSocket APIs", e);
+            isError = true;
+        }
+        if (isError) {
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred " +
+                    "while migrating WebSocket APIs for all tenants");
+        } else {
+            log.info("WSO2 API-M Migration Task : Completed migrating WebSocket APIs for all tenants");
         }
     }
 
-    public void removeUnnecessaryFaultHandlers() {
+    public void removeUnnecessaryFaultHandlers() throws APIMigrationException {
+        boolean isError = false;
+        log.info("WSO2 API-M Migration Task : Started removing unnecessary fault handlers from fault sequences" +
+                " for all tenants");
         try {
             List<Tenant> tenants = APIUtil.getAllTenantsWithSuperTenant();
             for (Tenant tenant : tenants) {
-                int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
-                APIUtil.loadTenantRegistry(apiTenantId);
-                startTenantFlow(tenant.getDomain(), apiTenantId,
-                        MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
-                this.registry = ServiceReferenceHolder.getInstance().getRegistryService()
-                        .getGovernanceSystemRegistry(apiTenantId);
-                // Fault Handlers that needs to be removed from fault sequences
-                String unnecessaryFaultHandler1 = "org.wso2.carbon.apimgt.usage.publisher.APIMgtFaultHandler";
-                String unnecessaryFaultHandler2 = "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtFaultHandler";
-                org.wso2.carbon.registry.api.Collection seqCollection = null;
-                String resourcePath = org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_LOCATION
-                        + RegistryConstants.PATH_SEPARATOR
-                        + org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT;
-                if (registry.resourceExists(resourcePath)) {
-                    seqCollection = (org.wso2.carbon.registry.api.Collection) registry
-                            .get(resourcePath);
-                } else {
-                    log.warn("WSO2 API-M Migration Task : No fault sequences found for tenant: " + tenant.getDomain());
-                }
-                if (seqCollection != null) {
-                    String[] childPaths = seqCollection.getChildren();
-                    for (String childPath : childPaths) {
-                        // Retrieve fault sequence from registry
-                        Resource sequence = registry.get(childPath);
-                        DocumentBuilderFactory factory = APIUtil.getSecuredDocumentBuilder();
-                        DocumentBuilder builder = factory.newDocumentBuilder();
-                        String content = new String((byte[]) sequence.getContent(), Charset.defaultCharset());
-                        Document doc = builder.parse(new InputSource(new StringReader(content)));
-                        // Retrieve elements with the tag name of "class" since the fault handlers that needs to
-                        // be removed are located within "class" tags
-                        NodeList list = doc.getElementsByTagName("class");
-                        for (int i = 0; i < list.getLength(); i++) {
-                            Node node = (Node) list.item(i);
-                            // Retrieve the element with "name" attribute to identify the fault handlers to be removed
-                            NamedNodeMap attr = node.getAttributes();
-                            Node namedItem = null;
-                            if (null != attr) {
-                                namedItem = attr.getNamedItem("name");
-                            }
-                            // Remove the relevant fault handlers
-                            if (unnecessaryFaultHandler1.equals(namedItem.getNodeValue()) || unnecessaryFaultHandler2
-                                    .equals(namedItem.getNodeValue())) {
-                                Node parentNode = node.getParentNode();
-                                parentNode.removeChild(node);
-                                parentNode.normalize();
+                log.info("WSO2 API-M Migration Task : Started removing unnecessary fault handlers " +
+                        "from fault sequences for tenant: " + tenant.getId() + '(' + tenant.getDomain() + ')');
+                try {
+                    int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
+                    APIUtil.loadTenantRegistry(apiTenantId);
+                    startTenantFlow(tenant.getDomain(), apiTenantId,
+                            MultitenantUtils.getTenantAwareUsername(APIUtil.getTenantAdminUserName(tenant.getDomain())));
+                    this.registry = ServiceReferenceHolder.getInstance().getRegistryService()
+                            .getGovernanceSystemRegistry(apiTenantId);
+                    // Fault Handlers that needs to be removed from fault sequences
+                    String unnecessaryFaultHandler1 = "org.wso2.carbon.apimgt.usage.publisher.APIMgtFaultHandler";
+                    String unnecessaryFaultHandler2 = "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtFaultHandler";
+                    org.wso2.carbon.registry.api.Collection seqCollection = null;
+                    String resourcePath = org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_LOCATION
+                            + RegistryConstants.PATH_SEPARATOR
+                            + org.wso2.carbon.apimgt.impl.APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT;
+                    if (registry.resourceExists(resourcePath)) {
+                        seqCollection = (org.wso2.carbon.registry.api.Collection) registry
+                                .get(resourcePath);
+                    } else {
+                        log.warn("WSO2 API-M Migration Task : No fault sequences found for tenant: " + tenant.getDomain());
+                    }
+                    if (seqCollection != null) {
+                        String[] childPaths = seqCollection.getChildren();
+                        for (String childPath : childPaths) {
+                            try {
+                                // Retrieve fault sequence from registry
+                                Resource sequence = registry.get(childPath);
+                                DocumentBuilderFactory factory = APIUtil.getSecuredDocumentBuilder();
+                                DocumentBuilder builder = factory.newDocumentBuilder();
+                                String content = new String((byte[]) sequence.getContent(), Charset.defaultCharset());
+                                Document doc = builder.parse(new InputSource(new StringReader(content)));
+                                // Retrieve elements with the tag name of "class" since the fault handlers that needs to
+                                // be removed are located within "class" tags
+                                NodeList list = doc.getElementsByTagName("class");
+                                for (int i = 0; i < list.getLength(); i++) {
+                                    Node node = (Node) list.item(i);
+                                    // Retrieve the element with "name" attribute to identify the fault handlers to be removed
+                                    NamedNodeMap attr = node.getAttributes();
+                                    Node namedItem = null;
+                                    if (null != attr) {
+                                        namedItem = attr.getNamedItem("name");
+                                    }
+                                    // Remove the relevant fault handlers
+                                    if (unnecessaryFaultHandler1.equals(namedItem.getNodeValue()) || unnecessaryFaultHandler2
+                                            .equals(namedItem.getNodeValue())) {
+                                        Node parentNode = node.getParentNode();
+                                        parentNode.removeChild(node);
+                                        parentNode.normalize();
+                                    }
+                                }
+                                // Convert the content to String
+                                String newContent = toString(doc);
+                                // Update the registry with the new content
+                                sequence.setContent(newContent);
+                                registry.put(childPath, sequence);
+                            } catch (RegistryException e) {
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "retrieving/updating fault sequences, childPath: " + childPath, e);
+                                isError = true;
+                            } catch (ParserConfigurationException e) {
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "getting new DocumentBuilder, childPath: " + childPath, e);
+                                isError = true;
+                            } catch (SAXException | IOException e) {
+                                log.error("WSO2 API-M Migration Task : Error while " +
+                                        "parsing fault sequences, childPath: " + childPath, e);
+                                isError = true;
+                            } catch (Exception e) {
+                                log.error("WSO2 API-M Migration Task : Error while removing " +
+                                        "unnecessary fault handlers from fault sequences, childPath: " + childPath, e);
+                                isError = true;
                             }
                         }
-                        // Convert the content to String
-                        String newContent = toString(doc);
-                        // Update the registry with the new content
-                        sequence.setContent(newContent);
-                        registry.put(childPath, sequence);
                     }
+                } catch (RegistryException e) {
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } catch (UserStoreException e) {
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } catch (APIManagementException e) {
+                    log.error("WSO2 API-M Migration Task : Error while retrieving tenant admin's username, " +
+                            "tenant domain: " + tenant.getDomain(), e);
+                    isError = true;
+                } catch (org.wso2.carbon.registry.api.RegistryException e) {
+                    log.error("WSO2 API-M Migration Task : Error while retrieving fault sequences, tenant domain: " +
+                            tenant.getDomain(), e);
+                    isError = true;
+                } finally {
+                    PrivilegedCarbonContext.endTenantFlow();
                 }
-                PrivilegedCarbonContext.endTenantFlow();
+
             }
-        } catch (RegistryException e) {
-            log.error("WSO2 API-M Migration Task : Error while initiating the registry", e);
         } catch (UserStoreException e) {
             log.error("WSO2 API-M Migration Task : Error while retrieving the tenants", e);
-        } catch (APIManagementException e) {
-            log.error("WSO2 API-M Migration Task : Error while retrieving tenant admin's username", e);
-        } catch (org.wso2.carbon.registry.api.RegistryException e) {
-            log.error("WSO2 API-M Migration Task : Error while retrieving fault sequences", e);
-        } catch (Exception e) {
-            log.error("WSO2 API-M Migration Task : Error while removing unnecessary fault handlers from fault sequences", e);
+            isError = true;
+        }
+        if (isError) {
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while " +
+                    "removing unnecessary fault handlers from fault sequences");
+        } else {
+            log.info("WSO2 API-M Migration Task : Completed removing unnecessary fault handlers from fault sequences" +
+                    " for all tenants");
         }
     }
 

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -295,37 +295,37 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                     tenantArtifactManager.updateGenericArtifact(apiArtifact);
                                 }
                             } catch (GovernanceException e) {
-                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-" +
-                                        apiInfoDTO.getApiVersion();
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "getting/setting attributes in artifact, apiId: " + apiId, e);
+                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-"
+                                        + apiInfoDTO.getApiVersion();
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "getting/setting attributes in artifact, apiId: " + apiId, e);
                                 isError = true;
                             } catch (APIManagementException e) {
-                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-" +
-                                        apiInfoDTO.getApiVersion();
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "getting tenant Admin User name from APIUtil, apiId: " + apiId, e);
+                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-"
+                                        + apiInfoDTO.getApiVersion();
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "getting tenant Admin User name from APIUtil, apiId: " + apiId, e);
                                 isError = true;
                             } catch (RegistryException e) {
-                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-" +
-                                        apiInfoDTO.getApiVersion();
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "accessing the registry, apiId: " + apiId, e);
+                                String apiId = apiInfoDTO.getApiProvider() + "-" + apiInfoDTO.getApiName() + "-"
+                                        + apiInfoDTO.getApiVersion();
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "accessing the registry, apiId: " + apiId, e);
                                 isError = true;
                             }
                         }
                     }
                 } catch (RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (APIManagementException e) {
-                    log.error("WSO2 API-M Migration Task : Error while Retrieving API artifact from the registry, " +
-                            "tenant domain: " + tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while Retrieving API artifact from the registry, "
+                            + "tenant domain: " + tenant.getDomain(), e);
                     isError = true;
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
@@ -336,8 +336,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
             isError = true;
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while " +
-                    "updating registry paths of API icons and WSDLs");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while "
+                    + "updating registry paths of API icons and WSDLs");
         } else {
             log.info("WSO2 API-M Migration Task : Completed updating registry paths of API icons and WSDL for all tenants");
         }
@@ -353,8 +353,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                 List<Environment> dynamicEnvironments;
                 List<APIInfoDTO> apiInfoDTOList = new ArrayList<>();
                 try {
-                    log.info("WSO2 API-M Migration Task : Starting API Revision related migration for tenant " +
-                            tenant.getId() + '(' + tenant.getDomain() + ')');
+                    log.info("WSO2 API-M Migration Task : Starting API Revision related migration for tenant "
+                            + tenant.getId() + '(' + tenant.getDomain() + ')');
                     dynamicEnvironments = ApiMgtDAO.getInstance().getAllEnvironments(tenant.getDomain());
                     APIUtil.loadTenantRegistry(tenant.getId());
                     startTenantFlow(tenant.getDomain(), tenant.getId(), APIUtil.getTenantAdminUserName(tenant.getDomain()));
@@ -368,18 +368,18 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                     }
                     //On exceptions in this stage, log the error with tenant details and continue for remaining tenants
                 } catch (GovernanceException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initializing the registry " + tenant.getId() +
-                            '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry " + tenant.getId()
+                            + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                     continue;
                 } catch (RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initializing the registry " + tenant.getId() +
-                            '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry " + tenant.getId()
+                            + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                     continue;
                 } catch (APIManagementException e) {
-                    log.error("WSO2 API-M Migration Task : Generic API Management Exception while performing revision " +
-                            "migration for " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Generic API Management Exception while performing revision "
+                            + "migration for " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                     continue;
                 }
@@ -422,12 +422,12 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                             }
                         }
                     } catch (GovernanceException e) {
-                        log.error("WSO2 API-M Migration Task : Error while fetching attributes from artifact: " +
-                                identifier, e);
+                        log.error("WSO2 API-M Migration Task : Error while fetching attributes from artifact: "
+                                + identifier, e);
                         isError = true;
                     } catch (APIManagementException e) {
-                        log.error("WSO2 API-M Migration Task : API Management Exception while getting API/API " +
-                                "Product from artifact: " + identifier, e);
+                        log.error("WSO2 API-M Migration Task : API Management Exception while getting API/API "
+                                + "Product from artifact: " + identifier, e);
                         isError = true;
                     }
                 }
@@ -442,16 +442,16 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                         try {
                             if (!StringUtils.equalsIgnoreCase(apiInfoDTO.getType(), APIConstants.API_PRODUCT)) {
                                 revisionId = apiProviderTenant.addAPIRevision(apiRevision, tenant.getDomain());
-                                log.info("WSO2 API-M Migration Task : Successfully created API Revision for " +
-                                        apiInfoDTO.getUuid());
+                                log.info("WSO2 API-M Migration Task : Successfully created API Revision for "
+                                        + apiInfoDTO.getUuid());
                             } else {
                                 revisionId = apiProviderTenant.addAPIProductRevision(apiRevision);
-                                log.info("WSO2 API-M Migration Task : Successfully created API Revision for " +
-                                        apiInfoDTO.getUuid());
+                                log.info("WSO2 API-M Migration Task : Successfully created API Revision for "
+                                        + apiInfoDTO.getUuid());
                             }
                         } catch (APIManagementException e) {
-                            log.error("WSO2 API-M Migration Task : Error while adding API/API Product Revision for " +
-                                    apiInfoDTO.getUuid(), e);
+                            log.error("WSO2 API-M Migration Task : Error while adding API/API Product Revision for "
+                                    + apiInfoDTO.getUuid(), e);
                             isError = true;
                             continue;
                         }
@@ -461,8 +461,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                         String environments = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_ENVIRONMENTS);
                         String[] arrOfEnvironments = environments.split(",");
                         if ("none".equals(environments)) {
-                            log.info("WSO2 API-M Migration Task : No gateway environments are configured for API " +
-                                    apiInfoDTO.getUuid() + ". Hence revision deployment is skipped.");
+                            log.info("WSO2 API-M Migration Task : No gateway environments are configured for API "
+                                    + apiInfoDTO.getUuid() + ". Hence revision deployment is skipped.");
                         } else {
                             for (String environment : arrOfEnvironments) {
                                 APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
@@ -489,8 +489,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                 if (optionalEnv != null) {
                                     dynamicEnv = optionalEnv.get();
                                 } else {
-                                    log.error("WSO2 API-M Migration Task : Error while retrieving dynamic " +
-                                            "environment of the label: " + label);
+                                    log.error("WSO2 API-M Migration Task : Error while retrieving dynamic "
+                                            + "environment of the label: " + label);
                                     isError = true;
                                     continue;
                                 }
@@ -503,8 +503,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                     apiRevisionDeployment.setDisplayOnDevportal(true);
                                     apiRevisionDeployments.add(apiRevisionDeployment);
                                 } else {
-                                    log.error("WSO2 API-M Migration Task : Vhosts are empty for the dynamic " +
-                                            "environment: " + dynamicEnv.getName());
+                                    log.error("WSO2 API-M Migration Task : Vhosts are empty for the dynamic "
+                                            + "environment: " + dynamicEnv.getName());
                                     isError = true;
                                 }
                             }
@@ -515,23 +515,23 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                 if (!StringUtils.equalsIgnoreCase(apiInfoDTO.getType(), APIConstants.API_PRODUCT)) {
                                     apiProviderTenant.deployAPIRevision(apiInfoDTO.getUuid(), revisionId,
                                             apiRevisionDeployments);
-                                    log.info("WSO2 API-M Migration Task : Successfully deployed API Revision for " +
-                                            apiInfoDTO.getUuid());
+                                    log.info("WSO2 API-M Migration Task : Successfully deployed API Revision for "
+                                            + apiInfoDTO.getUuid());
                                 } else {
                                     apiProviderTenant.deployAPIProductRevision(apiInfoDTO.getUuid(), revisionId,
                                             apiRevisionDeployments);
-                                    log.info("WSO2 API-M Migration Task : Successfully deployed API Product Revision" +
-                                            " for " + apiInfoDTO.getUuid());
+                                    log.info("WSO2 API-M Migration Task : Successfully deployed API Product Revision"
+                                            + " for " + apiInfoDTO.getUuid());
                                 }
                             } catch (APIManagementException e) {
-                                log.error("WSO2 API-M Migration Task : Error while deploying API/API Product " +
-                                        "Revision for " + apiInfoDTO.getUuid(), e);
+                                log.error("WSO2 API-M Migration Task : Error while deploying API/API Product "
+                                        + "Revision for " + apiInfoDTO.getUuid(), e);
                                 isError = true;
                             }
                         }
                     } catch (GovernanceException e) {
-                        log.error("WSO2 API-M Migration Task : Error while fetching registry artifact by UUID: " +
-                                apiInfoDTO.getUuid(), e);
+                        log.error("WSO2 API-M Migration Task : Error while fetching registry artifact by UUID: "
+                                + apiInfoDTO.getUuid(), e);
                         isError = true;
                     }
                 }
@@ -541,8 +541,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
         }
 
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during Revision Related " +
-                    "Migration, hence could not create/deploy revisions for some artifacts");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during Revision Related "
+                    + "Migration, hence could not create/deploy revisions for some artifacts");
         } else {
             log.info("WSO2 API-M Migration Task : Completed API Revision related migration for all tenants");
         }
@@ -575,25 +575,25 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                     try {
                         Certificate certificate = trustStore.getCertificate(alias);
                         if (certificate != null) {
+                            log.info("WSO2 API-M Migration Task : Adding encoded certificate content of alias: "
+                                    + alias + " to DB");
                             byte[] encoded = Base64.encodeBase64(certificate.getEncoded());
                             String base64EncodedString = BEGIN_CERTIFICATE_STRING.concat(new String(encoded)).concat("\n")
                                     .concat(END_CERTIFICATE_STRING);
                             base64EncodedString = Base64.encodeBase64URLSafeString(base64EncodedString.getBytes());
                             certificateMap.put(alias, base64EncodedString);
-                            log.info("WSO2 API-M Migration Task : Adding encoded certificate content of alias: " + alias
-                                    + " to DB");
                         } else {
-                            log.error("WSO2 API-M Migration Task : Error while retrieving endpoint certificate for" +
-                                    " alias: " + alias + ". The certificate does not exist in the trust store.");
+                            log.error("WSO2 API-M Migration Task : Error while retrieving endpoint certificate for"
+                                    + " alias: " + alias + ". The certificate does not exist in the trust store.");
                             isError = true;
                         }
                     } catch (KeyStoreException e) {
-                        log.error("WSO2 API-M Migration Task : Error while " +
-                                "getting certificate from trust store for alias: " + alias, e);
+                        log.error("WSO2 API-M Migration Task : Error while "
+                                + "getting certificate from trust store for alias: " + alias, e);
                         isError = true;
                     } catch (CertificateException e) {
-                        log.error("WSO2 API-M Migration Task : Error while " +
-                                "encoding certificate for alias: " + alias, e);
+                        log.error("WSO2 API-M Migration Task : Error while "
+                                + "encoding certificate for alias: " + alias, e);
                         isError = true;
                     }
                 }
@@ -607,8 +607,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
             isError = true;
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during Endpoint " +
-                    "Certificate Migration, hence could not migrate certificates for some artifacts.");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during Endpoint "
+                    + "Certificate Migration, hence could not migrate certificates for some artifacts.");
         } else {
             log.info("WSO2 API-M Migration Task : Completed Migrating Endpoint Certificates");
         }
@@ -679,8 +679,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                 }
                 environment.setVhosts(vhosts);
                 environments.add(environment);
-                log.info("WSO2 API-M Migration Task : Converting label " + labelDTO.getName() + "of tenant " +
-                        labelDTO.getTenantDomain() + " to a Vhost");
+                log.info("WSO2 API-M Migration Task : Converting label " + labelDTO.getName() + "of tenant "
+                        + labelDTO.getTenantDomain() + " to a Vhost");
             }
             // insert dynamic environments
             apiMgtDAO.addDynamicGatewayEnvironments(environments);
@@ -737,38 +737,39 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                                 APIUtil.getTenantAdminUserName(tenant.getDomain()));
                                         apiProviderTenant.saveAsyncApiDefinition(api, apiDefinition);
                                     } else {
-                                        log.error("WSO2 API-M Migration Task : Async Api definition is not added for the API " +
-                                                artifact.getAttribute(Constants.API_OVERVIEW_NAME)
+                                        log.error("WSO2 API-M Migration Task : "
+                                                + "Async Api definition is not added for the API "
+                                                + artifact.getAttribute(Constants.API_OVERVIEW_NAME)
                                                 + " due to returned API is null");
                                         isError = true;
                                     }
                                 }
                             } catch (GovernanceException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "fetching attributes from artifact, artifact path: ", e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "fetching attributes from artifact, artifact path: ", e);
                                 isError = true;
                             } catch (APIManagementException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "generating/saving Async API Definition, artifact path: ", e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "generating/saving Async API Definition, artifact path: ", e);
                                 isError = true;
                             } catch (APIMigrationException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "accessing ApiMgtDAO for migrating WebSocket APIs, artifact path: ", e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "accessing ApiMgtDAO for migrating WebSocket APIs, artifact path: ", e);
                                 isError = true;
                             }
                         }
                     }
                 } catch (RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (APIManagementException e) {
-                    log.error("WSO2 API-M Migration Task : Error while accessing APIUtil " +
-                            "for migrating WebSocket APIs, tenant domain: " + tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while accessing APIUtil "
+                            + "for migrating WebSocket APIs, tenant domain: " + tenant.getDomain(), e);
                     isError = true;
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
@@ -786,8 +787,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
             isError = true;
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred " +
-                    "while migrating WebSocket APIs for all tenants");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred "
+                    + "while migrating WebSocket APIs for all tenants");
         } else {
             log.info("WSO2 API-M Migration Task : Completed migrating WebSocket APIs for all tenants");
         }
@@ -795,13 +796,13 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
 
     public void removeUnnecessaryFaultHandlers() throws APIMigrationException {
         boolean isError = false;
-        log.info("WSO2 API-M Migration Task : Started removing unnecessary fault handlers from fault sequences" +
-                " for all tenants");
+        log.info("WSO2 API-M Migration Task : Started removing unnecessary fault handlers from fault sequences"
+                + " for all tenants");
         try {
             List<Tenant> tenants = APIUtil.getAllTenantsWithSuperTenant();
             for (Tenant tenant : tenants) {
-                log.info("WSO2 API-M Migration Task : Started removing unnecessary fault handlers " +
-                        "from fault sequences for tenant: " + tenant.getId() + '(' + tenant.getDomain() + ')');
+                log.info("WSO2 API-M Migration Task : Started removing unnecessary fault handlers "
+                        + "from fault sequences for tenant: " + tenant.getId() + '(' + tenant.getDomain() + ')');
                 try {
                     int apiTenantId = tenantManager.getTenantId(tenant.getDomain());
                     APIUtil.loadTenantRegistry(apiTenantId);
@@ -857,39 +858,39 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                 sequence.setContent(newContent);
                                 registry.put(childPath, sequence);
                             } catch (RegistryException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "retrieving/updating fault sequences, childPath: " + childPath, e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "retrieving/updating fault sequences, childPath: " + childPath, e);
                                 isError = true;
                             } catch (ParserConfigurationException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "getting new DocumentBuilder, childPath: " + childPath, e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "getting new DocumentBuilder, childPath: " + childPath, e);
                                 isError = true;
                             } catch (SAXException | IOException e) {
-                                log.error("WSO2 API-M Migration Task : Error while " +
-                                        "parsing fault sequences, childPath: " + childPath, e);
+                                log.error("WSO2 API-M Migration Task : Error while "
+                                        + "parsing fault sequences, childPath: " + childPath, e);
                                 isError = true;
                             } catch (Exception e) {
-                                log.error("WSO2 API-M Migration Task : Error while removing " +
-                                        "unnecessary fault handlers from fault sequences, childPath: " + childPath, e);
+                                log.error("WSO2 API-M Migration Task : Error while removing "
+                                        + "unnecessary fault handlers from fault sequences, childPath: " + childPath, e);
                                 isError = true;
                             }
                         }
                     }
                 } catch (RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (APIManagementException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving tenant admin's username, " +
-                            "tenant domain: " + tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving tenant admin's username, "
+                            + "tenant domain: " + tenant.getDomain(), e);
                     isError = true;
                 } catch (org.wso2.carbon.registry.api.RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving fault sequences, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving fault sequences, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
@@ -901,11 +902,11 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
             isError = true;
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while " +
-                    "removing unnecessary fault handlers from fault sequences");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while "
+                    + "removing unnecessary fault handlers from fault sequences");
         } else {
-            log.info("WSO2 API-M Migration Task : Completed removing unnecessary fault handlers from fault sequences" +
-                    " for all tenants");
+            log.info("WSO2 API-M Migration Task : Completed removing unnecessary fault handlers from fault sequences"
+                    + " for all tenants");
         }
     }
 

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateUUIDToDB.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateUUIDToDB.java
@@ -97,16 +97,16 @@ public class MigrateUUIDToDB extends MigrationClientBase{
                         }
                     }
                 } catch (RegistryException e) {
-                    log.error("WSO2 API-M Migration Task : Error while initiation the registry, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while initiation the registry, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: " +
-                            tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving the tenant ID, tenant domain: "
+                            + tenant.getDomain(), e);
                     isError = true;
                 } catch (APIManagementException e) {
-                    log.error("WSO2 API-M Migration Task : Error while retrieving API artifact from the registry, " +
-                            "tenant domain: " + tenant.getDomain(), e);
+                    log.error("WSO2 API-M Migration Task : Error while retrieving API artifact from the registry, "
+                            + "tenant domain: " + tenant.getDomain(), e);
                     isError = true;
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
@@ -119,8 +119,8 @@ public class MigrateUUIDToDB extends MigrationClientBase{
             isError = true;
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while " +
-                    "adding API UUID and STATUS to AM_API table for all tenants");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred while "
+                    + "adding API UUID and STATUS to AM_API table for all tenants");
         } else {
             log.info("WSO2 API-M Migration Task : Added API UUID and STATUS to AM_API table for all tenants");
         }

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClientBase.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClientBase.java
@@ -410,8 +410,8 @@ public abstract class MigrationClientBase {
         log.info("WSO2 API-M Migration Task : Start updating registry API artifacts");
         for (Tenant tenant : getTenantsArray()) {
             registryService.startTenantFlow(tenant);
-            log.info("WSO2 API-M Migration Task : Updating API artifacts for tenant " + tenant.getId() +
-                    '(' + tenant.getDomain() + ')');
+            log.info("WSO2 API-M Migration Task : Updating API artifacts for tenant " + tenant.getId()
+                    + '(' + tenant.getDomain() + ')');
             GenericArtifact[] artifacts = registryService.getGenericAPIArtifacts();
             for (GenericArtifact artifact : artifacts) {
                 try {
@@ -426,12 +426,12 @@ public abstract class MigrationClientBase {
                         registryService.updateEnableStoreInRxt(path, artifact);
                     }
                 } catch (GovernanceException e) {
-                    log.error("WSO2 API-M Migration Task : Error while accessing API artifact " +
-                            "in registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Error while accessing API artifact "
+                            + "in registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                 } catch (RegistryException | UserStoreException e) {
-                    log.error("WSO2 API-M Migration Task : Error while updating API artifact " +
-                            "in the registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    log.error("WSO2 API-M Migration Task : Error while updating API artifact "
+                            + "in the registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
                     isError = true;
                 }
             }
@@ -440,8 +440,8 @@ public abstract class MigrationClientBase {
             registryService.endTenantFlow();
         }
         if (isError) {
-            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during " +
-                    "Updating API artifacts of tenants");
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during "
+                    + "Updating API artifacts of tenants");
         } else {
             log.info("WSO2 API-M Migration Task : Completed Updating registry API artifacts");
         }
@@ -522,11 +522,11 @@ public abstract class MigrationClientBase {
                         log.info("WSO2 API-M Migration Task : Successfully migrated debug_json_fault.xml in registry"
                                 + " for tenant: " + tenant.getDomain() + ", tenant id: " + tenant.getId());
                     } catch (UserStoreException e) {
-                        log.error("Error in updating debug_json_fault.xml in registry for tenant: " +
-                                tenant.getDomain() + ", tenant id: " + tenant.getId(), e);
+                        log.error("Error in updating debug_json_fault.xml in registry for tenant: "
+                                + tenant.getDomain() + ", tenant id: " + tenant.getId(), e);
                     } catch (RegistryException e) {
-                        log.error("Error in updating debug_json_fault.xml in registry for tenant: " +
-                                tenant.getDomain() + ", tenant id: " + tenant.getId(), e);
+                        log.error("Error in updating debug_json_fault.xml in registry for tenant: "
+                                + tenant.getDomain() + ", tenant id: " + tenant.getId(), e);
                     }
                 }
             } finally {

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClientBase.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrationClientBase.java
@@ -406,14 +406,15 @@ public abstract class MigrationClientBase {
      * @throws APIMigrationException
      */
     public void updateGenericAPIArtifacts(RegistryService registryService) throws APIMigrationException {
+        boolean isError = false;
         log.info("WSO2 API-M Migration Task : Start updating registry API artifacts");
         for (Tenant tenant : getTenantsArray()) {
-            try {
-                registryService.startTenantFlow(tenant);
-                log.info("WSO2 API-M Migration Task : Updating API artifacts for tenant " + tenant.getId() +
-                        '(' + tenant.getDomain() + ')');
-                GenericArtifact[] artifacts = registryService.getGenericAPIArtifacts();
-                for (GenericArtifact artifact : artifacts) {
+            registryService.startTenantFlow(tenant);
+            log.info("WSO2 API-M Migration Task : Updating API artifacts for tenant " + tenant.getId() +
+                    '(' + tenant.getDomain() + ')');
+            GenericArtifact[] artifacts = registryService.getGenericAPIArtifacts();
+            for (GenericArtifact artifact : artifacts) {
+                try {
                     String path = artifact.getPath();
                     if (registryService.isGovernanceRegistryResourceExists(path)) {
                         Object apiResource = registryService.getGovernanceRegistryResource(path);
@@ -422,21 +423,27 @@ public abstract class MigrationClientBase {
                         }
                         registryService.updateGenericAPIArtifactsForAccessControl(path, artifact);
                         registryService.updateGenericAPIArtifact(path, artifact);
-                        registryService.updateEnableStoreInRxt(path,artifact);
+                        registryService.updateEnableStoreInRxt(path, artifact);
                     }
+                } catch (GovernanceException e) {
+                    log.error("WSO2 API-M Migration Task : Error while accessing API artifact " +
+                            "in registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    isError = true;
+                } catch (RegistryException | UserStoreException e) {
+                    log.error("WSO2 API-M Migration Task : Error while updating API artifact " +
+                            "in the registry for tenant " + tenant.getId() + '(' + tenant.getDomain() + ')', e);
+                    isError = true;
                 }
-                log.info("WSO2 API-M Migration Task : Completed Updating API artifacts for tenant" + tenant.getId()
-                        + '(' + tenant.getDomain() + ')');
-            } catch (GovernanceException e) {
-                log.error("WSO2 API-M Migration Task : Error while accessing API artifact in registry for tenant "
-                        + tenant.getId() + '(' + tenant.getDomain() + ')', e);
-            } catch (RegistryException | UserStoreException e) {
-                log.error("WSO2 API-M Migration Task : Error while updating API artifact in the registry for tenant "
-                        + tenant.getId() + '(' + tenant.getDomain() + ')', e);
-            } finally {
-                registryService.endTenantFlow();
             }
-            log.info("WSO2 API-M Migration Task : RXT resource migration done for all the tenants");
+            log.info("WSO2 API-M Migration Task : Completed Updating API artifacts for tenant" + tenant.getId()
+                    + '(' + tenant.getDomain() + ')');
+            registryService.endTenantFlow();
+        }
+        if (isError) {
+            throw new APIMigrationException("WSO2 API-M Migration Task : Error/s occurred during " +
+                    "Updating API artifacts of tenants");
+        } else {
+            log.info("WSO2 API-M Migration Task : Completed Updating registry API artifacts");
         }
     }
 


### PR DESCRIPTION
## Purpose
When migrations fail due to errors, only the first occurrence is identified due to exiting tenant/artefact wise iterations. Exception handling is needed to be modified to continue on errors to identify all errors at once.
Fixing : https://github.com/wso2/api-manager/issues/615

## Goals
Identify all errors in one migration attempt.

## Approach
Exceptions thrown within an iteration is caught and logged without exiting the loop. 
Error state is maintained and logged at the end.

## Related PRs
#254 
#304 
#306 