### PR TITLE
[4.2.0] Disable ExtendedAPIMConfigService for 4.2.0 onwards

### DIFF
--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/client/V410Migration.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/client/V410Migration.java
@@ -24,7 +24,6 @@ import org.wso2.carbon.apimgt.migration.migrator.commonMigrators.PostDBScriptMig
 import org.wso2.carbon.apimgt.migration.migrator.commonMigrators.PreDBScriptMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.v410.V410DBDataMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.v410.V410RegistryResourceMigrator;
-import org.wso2.carbon.apimgt.migration.util.APIUtil;
 import org.wso2.carbon.apimgt.migration.util.Constants;
 import org.wso2.carbon.user.api.UserStoreException;
 
@@ -69,10 +68,6 @@ public class V410Migration extends VersionMigrator {
         postDBScriptMigratorForAmDb.run();
         log.info("WSO2 API-M Migration Task : Successfully executed post migration DB scripts");
 
-        // Setting ExtendedAPIMConfigService as disabled. This extended implementation is only needed and enabled for migrations
-        // which are from before APIM 4.1. Also need to disable this for future migrations such as from APIM 4.2 to APIM 4.3.
-        APIUtil.setDisabledExtendedAPIMConfigService(true);
-        log.info("WSO2 API-M Migration Task : ExtendedAPIMConfigService is disabled");
         log.info("WSO2 API-M Migration Task : Completed migration from " + getPreviousVersion() + " to " + getCurrentVersion() + "...");
     }
 }

--- a/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/client/V420Migration.java
+++ b/components/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/migrator/client/V420Migration.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.migration.APIMigrationException;
 import org.wso2.carbon.apimgt.migration.migrator.VersionMigrator;
 import org.wso2.carbon.apimgt.migration.migrator.v420.V420RegistryResourceMigrator;
+import org.wso2.carbon.apimgt.migration.util.APIUtil;
 import org.wso2.carbon.apimgt.migration.util.Constants;
 import org.wso2.carbon.user.api.UserStoreException;
 
@@ -40,6 +41,11 @@ public class V420Migration extends VersionMigrator {
         log.info("WSO2 API-M Migration Task : Starting migration from " + getPreviousVersion() + " to "
                 + getCurrentVersion() + "...");
         log.info("--------------------------------------------------------------------------------------------------");
+
+        // Setting ExtendedAPIMConfigService as disabled. This extended implementation is only needed and enabled for migrations
+        // which are coming from versions before APIM 4.1. Also need to disable this for future migrations such as from APIM 4.2 to APIM 4.3.
+        APIUtil.setDisabledExtendedAPIMConfigService(true);
+        log.info("WSO2 API-M Migration Task : ExtendedAPIMConfigService is disabled");
 
         log.info(
                 "WSO2 API-M Migration Task : Starting registry resource migration from " + getPreviousVersion() + " to "


### PR DESCRIPTION
## Purpose
Setting ExtendedAPIMConfigService as disabled. This extended implementation is only needed and enabled for migrations which are coming from versions before APIM 4.1.0
Also need to disable this for future migrations such as from APIM 4.2.0 to APIM 4.3.0

i.e. : add it to `V420Migration`, `V430Migration`, `V440Migration` so on.