### PR TITLE
Add logs when artifact migration for tenant skipped

### DIFF
--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom310.java
@@ -362,6 +362,9 @@ public class MigrateFrom310 extends MigrationClientBase implements MigrationClie
                         }
                         APIMgtDAO apiMgtDAO = APIMgtDAO.getInstance();
                         apiMgtDAO.updateAPIType(apiInfoDTOList, tenant.getId(), tenant.getDomain());
+                    } else {
+                        log.info("WSO2 API-M Migration Task : updating API Type in DB, skipped for tenant: "
+                                + tenant.getId() + "(" + tenant.getDomain() + ") as no api artifacts found in registry");
                     }
                 } catch (RegistryException e) {
                     log.error("WSO2 API-M Migration Task : Error while initiation the registry, tenant domain: "

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateFrom320.java
@@ -374,6 +374,8 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                             continue;
                         }
                     } else {
+                        log.info("WSO2 API-M Migration Task : API Revision related migration skipped for tenant: "
+                                + tenant.getId() + "(" + tenant.getDomain() + ") as no api artifacts found in registry" );
                         continue;
                     }
                     //On exceptions in this stage, log the error with tenant details and continue for remaining tenants
@@ -772,6 +774,9 @@ public class MigrateFrom320 extends MigrationClientBase implements MigrationClie
                                 isError = true;
                             }
                         }
+                    } else {
+                        log.info("WSO2 API-M Migration Task : Migrating WebSocket APIs, skipped for tenant: "
+                                + tenant.getId() + "(" + tenant.getDomain() + ") as no api artifacts found in registry");
                     }
                 } catch (RegistryException e) {
                     log.error("WSO2 API-M Migration Task : Error while initializing the registry, tenant domain: "

--- a/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateUUIDToDB.java
+++ b/migration-client/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/MigrateUUIDToDB.java
@@ -98,6 +98,9 @@ public class MigrateUUIDToDB extends MigrationClientBase{
                                 isError = true;
                             }
                         }
+                    } else {
+                        log.info("WSO2 API-M Migration Task : Adding API UUID and STATUS to AM_API table, skipped for tenant: "
+                                + tenant.getId() + "(" + tenant.getDomain() + ") as no api artifacts found in registry");
                     }
                 } catch (RegistryException e) {
                     log.error("WSO2 API-M Migration Task : Error while initiation the registry, tenant domain: "


### PR DESCRIPTION
## Description
Add logs when artifact migration for tenant skipped due to no API artifacts found in registry.
Related to fix done for https://github.com/wso2/api-manager/issues/1103

